### PR TITLE
Show mgem/mruby revisions on compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 mruby/
 pkg/
+
+src/REVISIONS.defs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 mruby/
 pkg/
-
 src/REVISIONS.defs

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,14 @@
 require 'fileutils'
 
-MRUBY_VERSION="1.2.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.2.0"
 
 file :mruby do
-  #sh "git clone --depth=1 https://github.com/mruby/mruby"
-  sh "curl -L --fail --retry 3 --retry-delay 1 https://github.com/mruby/mruby/archive/1.2.0.tar.gz -s -o - | tar zxf -"
-  FileUtils.mv("mruby-1.2.0", "mruby")
+  cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"
+  if MRUBY_VERSION != 'master'
+    cmd << " && cd mruby"
+    cmd << " && git fetch --tags && git checkout $(git rev-parse #{MRUBY_VERSION})"
+  end
+  sh cmd
 end
 
 APP_NAME=ENV["APP_NAME"] || "haconiwa"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -17,6 +17,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-array-ext' , :core => 'mruby-array-ext'
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
   spec.add_dependency 'mruby-time'      , :core => 'mruby-time'
+  spec.add_dependency 'mruby-sprintf'   , :core => 'mruby-sprintf'
 
   spec.add_dependency 'mruby-cgroup'    , :github => 'matsumoto-r/mruby-cgroup'
   spec.add_dependency 'mruby-capability', :github => 'matsumoto-r/mruby-capability'

--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -3,6 +3,8 @@ def __main__(argv)
   case argv[0]
   when "version"
     puts "haconiwa: v#{Haconiwa::VERSION}"
+  when "revisions"
+    Haconiwa::Cli.revisions
   when "run"
     Haconiwa::Cli.run(argv)
   when "attach"
@@ -11,9 +13,10 @@ def __main__(argv)
     puts <<-USAGE
 haconiwa - The MRuby on Container
 commands:
-    run     - run the container
-    attach  - attach to existing container
-    version - show version
+    run       - run the container
+    attach    - attach to existing container
+    version   - show version
+    revisions - show mgem/mruby revisions which haconiwa bin uses
     USAGE
   end
 end

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -39,6 +39,12 @@ module Haconiwa
       base.attach(*exe)
     end
 
+    def self.revisions
+      puts "mgem and mruby revisions:"
+      puts "--------"
+      puts Haconiwa.mrbgem_revisions.to_a.map{|a| sprintf "%-24s%s", *a }.join("\n")
+    end
+
     private
 
     def self.get_script_and_eval(args)

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -5,20 +5,21 @@
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
 struct mrbgem_revision {
-  char* gemname;
-  char* revision;
+  const char* gemname;
+  const char* revision;
 };
 
-static mrb_value mrb_haconiwa_mrgbem_versions(mrb_state *mrb, mrb_value self)
+const struct mrbgem_revision GEMS[] = {
+  #include "REVISIONS.defs"
+  {NULL, NULL},
+};
+
+static mrb_value mrb_haconiwa_mrgbem_revisions(mrb_state *mrb, mrb_value self)
 {
-  struct mrbgem_revision gems[] = {
-    #include "REVISIONS.defs"
-    {NULL, NULL},
-  };
   mrb_value ha = mrb_hash_new(mrb);
 
-  for (int i = 0; gems[i].gemname != NULL; ++i) {
-    mrb_hash_set(mrb, ha, mrb_str_new_cstr(mrb, gems[i].gemname), mrb_str_new_cstr(mrb, gems[i].revision));
+  for (int i = 0; GEMS[i].gemname != NULL; ++i) {
+    mrb_hash_set(mrb, ha, mrb_str_new_cstr(mrb, GEMS[i].gemname), mrb_str_new_cstr(mrb, GEMS[i].revision));
   }
 
   return ha;
@@ -28,7 +29,7 @@ void mrb_haconiwa_gem_init(mrb_state *mrb)
 {
   struct RClass *haconiwa;
   haconiwa = mrb_define_module(mrb, "Haconiwa");
-  mrb_define_class_method(mrb, haconiwa, "mrbgem_versions", mrb_haconiwa_mrgbem_versions, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, haconiwa, "mrbgem_revisions", mrb_haconiwa_mrgbem_revisions, MRB_ARGS_NONE());
 
   DONE;
 }

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -1,10 +1,27 @@
 #include "mruby.h"
+#include "mruby/string.h"
+#include "mruby/hash.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
+struct mrbgem_revision {
+  char* gemname;
+  char* revision;
+};
+
 static mrb_value mrb_haconiwa_mrgbem_versions(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(0);
+  struct mrbgem_revision gems[] = {
+    #include "REVISIONS.defs"
+    {NULL, NULL},
+  };
+  mrb_value ha = mrb_hash_new(mrb);
+
+  for (int i = 0; gems[i].gemname != NULL; ++i) {
+    mrb_hash_set(mrb, ha, mrb_str_new_cstr(mrb, gems[i].gemname), mrb_str_new_cstr(mrb, gems[i].revision));
+  }
+
+  return ha;
 }
 
 void mrb_haconiwa_gem_init(mrb_state *mrb)

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -1,0 +1,21 @@
+#include "mruby.h"
+
+#define DONE mrb_gc_arena_restore(mrb, 0);
+
+static mrb_value mrb_haconiwa_mrgbem_versions(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(0);
+}
+
+void mrb_haconiwa_gem_init(mrb_state *mrb)
+{
+  struct RClass *haconiwa;
+  haconiwa = mrb_define_module(mrb, "Haconiwa");
+  mrb_define_class_method(mrb, haconiwa, "mrbgem_versions", mrb_haconiwa_mrgbem_versions, MRB_ARGS_NONE());
+
+  DONE;
+}
+
+void mrb_haconiwa_gem_final(mrb_state *mrb)
+{
+}


### PR DESCRIPTION
This is perfect for debug!

```console
$ ./mruby/bin/haconiwa revisions
mgem and mruby revisions:
--------
MRUBY_CORE_REVISION     22464fe5a0a10f2b077eaba109ce1e912e4a77de
mruby-argtable          d0077ef2504be4cb3ae8e855dfe88a532fb6997b
mruby-capability        ba12370b02abd696eeede4c3413a0aa948c7af17
mruby-cgroup            489058afba3dfae450513ea1d40c8e0bb007fee6
mruby-dir               0c3c538855dd15208d34fee96b13675e564bb4b6
mruby-exec              f70bbf735f8370729dcb2cab019d593c4a5d5617
mruby-io                93d481d4b49829e37b1f501c7307663c6327dfab
mruby-mount             dabaa7c487e09a878893d06573500e851cb20364
mruby-namespace         f5dbc47b3174a117e26d5ff6e21c1322a650e45f
mruby-process           e532ff8837ebed35bdc03f26aed6a9105bbd7c44
mruby-procutil          60a05763a2720d31c62750728542b05b89d7ada0
mruby-resource          ed74671bd4c653434367ec8fb05e094d2b2cff20
```