### PR TITLE
Fixed libargtable(2) package name for Debian and Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install them and then download from [latest](https://github.com/haconiwa/haconiw
 ```bash
 sudo yum install libcap argtable
 # For Ubuntu or Debian it may be:
-#     sudo apt-get install libcap2 libargtable2
+#     sudo apt-get install libcap2 libargtable2-0
 
 VERSION=0.1.0
 wget https://github.com/haconiwa/haconiwa/releases/download/v${VERSION}/haconiwa-v${VERSION}.x86_64-pc-linux-gnu.tgz


### PR DESCRIPTION
I tried to install on my Debian sid machine, `libargtable2` was not found.

```
% sudo apt-get install libcap2 libargtable2
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libargtable2
```

The package name is `libargtable2-0` for Debian and Ubuntu.

See also:

https://packages.debian.org/search?suite=all&searchon=names&keywords=libargtable2
http://packages.ubuntu.com/search?suite=all&searchon=names&keywords=libargtable2