### PR TITLE
Use static link argtable3

### DIFF
--- a/LICENSE_argtable3
+++ b/LICENSE_argtable3
@@ -1,0 +1,25 @@
+Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+<sheitmann@users.sourceforge.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of STEWART HEITMANN nor the  names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 ## Install binary
 
-Pre-required packages: `libcap` and `libargtable(2)`.
+Pre-required package: `libcap`.
 
 Install them and then download from [latest](https://github.com/haconiwa/haconiwa/releases):
 
 ```bash
-sudo yum install libcap argtable
+sudo yum install libcap
 # For Ubuntu or Debian it may be:
-#     sudo apt-get install libcap2 libargtable2
+#     sudo apt-get install libcap2
 
 VERSION=0.1.0
 wget https://github.com/haconiwa/haconiwa/releases/download/v${VERSION}/haconiwa-v${VERSION}.x86_64-pc-linux-gnu.tgz

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,7 +9,6 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
 
   spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
   spec.add_dependency 'mruby-io'        , :mgem => 'mruby-io'
-  spec.add_dependency 'mruby-argtable'  , :mgem => 'mruby-argtable'
   spec.add_dependency 'mruby-eval'      , :core => 'mruby-eval'
   spec.add_dependency 'mruby-bin-mirb'  , :core => 'mruby-bin-mirb'
   spec.add_dependency 'mruby-bin-mruby' , :core => 'mruby-bin-mruby'
@@ -27,6 +26,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-exec'      , :github => 'haconiwa/mruby-exec'
   spec.add_dependency 'mruby-namespace' , :github => 'haconiwa/mruby-namespace'
   spec.add_dependency 'mruby-mount'     , :github => 'haconiwa/mruby-mount'
+  spec.add_dependency 'mruby-argtable'  , :github => 'udzura/mruby-argtable', :branch => 'static-link-argtable3'
 
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do


### PR DESCRIPTION
Current status:

```console
$ ls -lh ./mruby/build/x86_64-pc-linux-gnu/bin/haconiwa 
-rwxr-xr-x 1 vagrant vagrant 748K  7月 13  2016 ./mruby/build/x86_64-pc-linux-gnu/bin/haconiwa

$ ldd ./mruby/build/x86_64-pc-linux-gnu/bin/haconiwa                                                                                                                          
        linux-vdso.so.1 =>  (0x00007fff15efc000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f2d46a3d000)
        libreadline.so.6 => /lib64/libreadline.so.6 (0x00007f2d467f7000)
        libncurses.so.5 => /lib64/libncurses.so.5 (0x00007f2d465cf000)
        libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00007f2d463a5000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f2d46189000)
        librt.so.1 => /lib64/librt.so.1 (0x00007f2d45f80000)
        libcap.so.2 => /lib64/libcap.so.2 (0x00007f2d45d7b000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f2d459b9000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f2d457b4000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2d46d49000)
        libattr.so.1 => /lib64/libattr.so.1 (0x00007f2d455af000
```