### PR TITLE
Lessen dependent dynamic-linked libraries

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,9 @@ desc "compile binary"
 task :compile => [:all] do
   bins = ["mruby", "mirb", APP_NAME]
   bins.each do |binname|
-    bin = %Q(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{binname})
-    sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
+    %W(#{mruby_root}/build/x86_64-pc-linux-gnu/bin/#{binname} #{mruby_root}/build/x86_64-pc-linux-gnu_mirb/bin/#{binname}).each do |bin|
+      sh "strip --strip-unneeded #{bin}" if File.exist?(bin)
+    end
   end
 end
 
@@ -89,9 +90,9 @@ namespace :release do
   end
 
   task :copy => ["release:clean", :compile] do
-    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu/bin/mruby    #{pwd}/tmp/hacorb"
-    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu/bin/mirb     #{pwd}/tmp/hacoirb"
-    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu/bin/haconiwa #{pwd}/tmp/haconiwa"
+    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu/bin/mruby     #{pwd}/tmp/hacorb"
+    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu_mirb/bin/mirb #{pwd}/tmp/hacoirb"
+    sh "cp #{mruby_root}/build/x86_64-pc-linux-gnu/bin/haconiwa  #{pwd}/tmp/haconiwa"
   end
 
   task :tarball => :copy do

--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ load File.expand_path("../mrblib/haconiwa/version.rb", __FILE__)
 pwd = File.expand_path("..", __FILE__)
 namespace :release do
   task :clean do
-    sh "rm -rf #{pwd}/tmp/*"
+    sh "rm -rf #{pwd}/tmp/* #{pwd}/pkg/*"
   end
 
   task :copy => ["release:clean", :compile] do

--- a/build_config.rb
+++ b/build_config.rb
@@ -20,6 +20,14 @@ MRuby::Build.new('x86_64-pc-linux-gnu') do |conf|
   gem_config(conf)
 end
 
+MRuby::Build.new('x86_64-pc-linux-gnu_mirb') do |conf|
+  toolchain :gcc
+
+  gem_config(conf)
+  conf.gem core: 'mruby-bin-mirb'
+  conf.bins = ["mirb"]
+end
+
 # MRuby::CrossBuild.new('i686-pc-linux-gnu') do |conf|
 #   toolchain :gcc
 

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -10,7 +10,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
   spec.add_dependency 'mruby-io'        , :mgem => 'mruby-io'
   spec.add_dependency 'mruby-eval'      , :core => 'mruby-eval'
-  spec.add_dependency 'mruby-bin-mirb'  , :core => 'mruby-bin-mirb'
+  #spec.add_dependency 'mruby-bin-mirb'  , :core => 'mruby-bin-mirb'
   spec.add_dependency 'mruby-bin-mruby' , :core => 'mruby-bin-mruby'
   spec.add_dependency 'mruby-print'     , :core => 'mruby-print'
   spec.add_dependency 'mruby-array-ext' , :core => 'mruby-array-ext'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -19,7 +19,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-sprintf'   , :core => 'mruby-sprintf'
 
   spec.add_dependency 'mruby-cgroup'    , :github => 'matsumoto-r/mruby-cgroup'
-  spec.add_dependency 'mruby-capability', :github => 'matsumoto-r/mruby-capability'
+  spec.add_dependency 'mruby-capability', :github => 'haconiwa/mruby-capability', :branch => 'static-link'
   spec.add_dependency 'mruby-resource'  , :github => 'harasou/mruby-resource'
   spec.add_dependency 'mruby-dir'       , :github => 'iij/mruby-dir' # with Dir#chroot
   spec.add_dependency 'mruby-procutil'  , :github => 'haconiwa/mruby-procutil'


### PR DESCRIPTION
Current status:

```console
$ ldd `which haconiwa`
        linux-vdso.so.1 =>  (0x00007ffd66bdd000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fecf2fea000)
        libreadline.so.6 => /lib64/libreadline.so.6 (0x00007fecf2da4000)
        libncurses.so.5 => /lib64/libncurses.so.5 (0x00007fecf2b7c000)
        libtinfo.so.5 => /lib64/libtinfo.so.5 (0x00007fecf2952000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fecf2736000)
        librt.so.1 => /lib64/librt.so.1 (0x00007fecf252d000)
        libcap.so.2 => /lib64/libcap.so.2 (0x00007fecf2328000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fecf1f66000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007fecf1d61000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fecf32f6000)
        libattr.so.1 => /lib64/libattr.so.1 (0x00007fecf1b5c000)
```