### PR TITLE
Implement create subcommand(bootstrap and provisioning)

### DIFF
--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -5,7 +5,7 @@ def __main__(argv)
     puts "haconiwa: v#{Haconiwa::VERSION}"
   when "revisions"
     Haconiwa::Cli.revisions
-  when "run"
+  when "start", "run"
     Haconiwa::Cli.run(argv)
   when "attach"
     Haconiwa::Cli.attach(argv)
@@ -15,7 +15,7 @@ def __main__(argv)
     puts <<-USAGE
 haconiwa - The MRuby on Container
 commands:
-    run       - run the container
+    start     - run the container
     attach    - attach to existing container
     kill      - kill the running container
     version   - show version

--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -5,6 +5,8 @@ def __main__(argv)
     puts "haconiwa: v#{Haconiwa::VERSION}"
   when "revisions"
     Haconiwa::Cli.revisions
+  when "create"
+    Haconiwa::Cli.create(argv)
   when "start", "run"
     Haconiwa::Cli.run(argv)
   when "attach"
@@ -15,6 +17,7 @@ def __main__(argv)
     puts <<-USAGE
 haconiwa - The MRuby on Container
 commands:
+    create    - create the container rootfs
     start     - run the container
     attach    - attach to existing container
     kill      - kill the running container

--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -7,6 +7,8 @@ def __main__(argv)
     Haconiwa::Cli.revisions
   when "create"
     Haconiwa::Cli.create(argv)
+  when "provision"
+    Haconiwa::Cli.provision(argv)
   when "start", "run"
     Haconiwa::Cli.run(argv)
   when "attach"
@@ -18,11 +20,14 @@ def __main__(argv)
 haconiwa - The MRuby on Container
 commands:
     create    - create the container rootfs
+    provision - provision already booted container rootfs
     start     - run the container
     attach    - attach to existing container
     kill      - kill the running container
     version   - show version
     revisions - show mgem/mruby revisions which haconiwa bin uses
+
+Invoke `haconiwa COMMAND -h' for details.
     USAGE
   end
 end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -118,6 +118,16 @@ module Haconiwa
       end
     end
 
+    def do_provision(ops)
+      unless ::File.directory?(self.root.to_s)
+        raise "Rootfs #{root} not yet bootstrapped. Run `haconiwa create' before provision."
+      end
+
+      validate_non_nil(@provision, "`config.provision' block must be defined to run provisioning")
+      @provision.select_ops(ops) unless ops.empty?
+      @provision.provision!(self.root)
+    end
+
     def start(*init_command)
       self.container_pid_file ||= default_container_pid_file
       LinuxRunner.new(self).run(init_command)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -9,7 +9,7 @@ module Haconiwa
                   :capabilities,
                   :attached_capabilities,
                   :signal_handler,
-                  :pid,
+                  :pid
 
     attr_reader   :init_command,
                   :uid,
@@ -50,6 +50,10 @@ module Haconiwa
     # aliases
     def chroot_to(dest)
       self.filesystem.chroot = dest
+    end
+
+    def root
+      filesystem.chroot
     end
 
     def add_mount_point(point, options)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -9,7 +9,7 @@ module Haconiwa
                   :capabilities,
                   :attached_capabilities,
                   :signal_handler,
-                  :pid
+                  :pid,
 
     attr_reader   :init_command,
                   :uid,
@@ -92,6 +92,16 @@ module Haconiwa
 
     def add_handler(sig, &b)
       @signal_handler.add_handler(sig, &b)
+    end
+
+    def bootstrap
+      @bootstrap ||= Bootstrap.new
+      yield(@bootstrap) if block_given?
+      @bootstrap
+    end
+
+    def create
+      @bootstrap.boot!(self.root)
     end
 
     def start(*init_command)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -110,9 +110,10 @@ module Haconiwa
       @provision
     end
 
-    def create
+    def create(no_provision)
+      validate_non_nil(@bootstrap, "`config.bootstrap' block must be defined to create rootfs")
       @bootstrap.boot!(self.root)
-      if @provision
+      if @provision and !no_provision
         @provision.provision!(self.root)
       end
     end
@@ -143,6 +144,12 @@ module Haconiwa
 
     def daemon?
       !! @daemon
+    end
+
+    def validate_non_nil(obj, msg)
+      unless obj
+        raise(msg)
+      end
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -104,8 +104,17 @@ module Haconiwa
       @bootstrap
     end
 
+    def provision
+      @provision ||= Provision.new
+      yield(@provision) if block_given?
+      @provision
+    end
+
     def create
       @bootstrap.boot!(self.root)
+      if @provision
+        @provision.provision!(self.root)
+      end
     end
 
     def start(*init_command)

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -5,28 +5,32 @@ module Haconiwa
     attr_accessor :strategy, :root,
                   :project_name, :os_type
 
-    def boot!(root)
-      self.root = root
+    def boot!(r)
+      self.root = Pathname.new(r)
+      self.project_name ||= File.basename(root.to_s)
       if File.directory?(root)
         log("Directory #{root} already bootstrapped.")
         return true
       end
 
-      cmd = RunCmd.new("bootstrap")
       case strategy
       when "lxc", "lxc-create"
-        bootstrap_with_lxc_template(cmd)
+        bootstrap_with_lxc_template
       else
         raise "Unsupported: #{strategy}"
       end
     end
 
-    def bootstrap_with_lxc_template(cmd)
+    def bootstrap_with_lxc_template
+      cmd = RunCmd.new("bootstrap.lxc")
+      log("Start bootstrapping rootfs with lxc-create...")
+
       unless system "which lxc-create"
         raise "lxc-create command may not be installed yet. Please install via your package manager."
       end
 
-      cmd.run(sprintf("lxc-create -n %s -t %s --dir %s", project_name, os_type, root))
+      cmd.run(sprintf("lxc-create -n %s -t %s --dir %s", project_name, os_type, root.to_str))
+      log("Success!")
       return true
     end
 

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -1,0 +1,38 @@
+module Haconiwa
+  class Bootstrap
+    def initialize
+    end
+    attr_accessor :strategy, :root,
+                  :project_name, :os_type
+
+    def boot!(root)
+      self.root = root
+      if File.directory?(root)
+        log("Directory #{root} already bootstrapped.")
+        return true
+      end
+
+      cmd = RunCmd.new("bootstrap")
+      case strategy
+      when "lxc", "lxc-create"
+        bootstrap_with_lxc_template(cmd)
+      else
+        raise "Unsupported: #{strategy}"
+      end
+    end
+
+    def bootstrap_with_lxc_template(cmd)
+      unless system "which lxc-create"
+        raise "lxc-create command may not be installed yet. Please install via your package manager."
+      end
+
+      cmd.run(sprintf("lxc-create -n %s -t %s --dir %s", project_name, os_type, root))
+      return true
+    end
+
+    private
+    def log(msg)
+      $stderr.puts msg.green
+    end
+  end
+end

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -3,7 +3,8 @@ module Haconiwa
     def initialize
     end
     attr_accessor :strategy, :root,
-                  :project_name, :os_type
+                  :project_name, :os_type,
+                  :arch, :variant, :components, :debian_release, :mirror_url
 
     def boot!(r)
       self.root = Pathname.new(r)
@@ -16,6 +17,8 @@ module Haconiwa
       case strategy
       when "lxc", "lxc-create"
         bootstrap_with_lxc_template
+      when "debootstrap"
+        bootstrap_with_debootstrap
       else
         raise "Unsupported: #{strategy}"
       end
@@ -25,11 +28,31 @@ module Haconiwa
       cmd = RunCmd.new("bootstrap.lxc")
       log("Start bootstrapping rootfs with lxc-create...")
 
-      unless system "which lxc-create"
+      unless system "which lxc-create >/dev/null"
         raise "lxc-create command may not be installed yet. Please install via your package manager."
       end
 
       cmd.run(sprintf("lxc-create -n %s -t %s --dir %s", project_name, os_type, root.to_str))
+      log("Success!")
+      return true
+    end
+
+    def bootstrap_with_debootstrap
+      cmd = RunCmd.new("bootstrap.debootstrap")
+      log("Start bootstrapping rootfs with debootstrap...")
+
+      unless system "which debootstrap >/dev/null"
+        raise "debootstrap command may not be installed yet. Please install via your package manager."
+      end
+
+      self.arch ||= "amd64" # TODO: detection
+      self.components ||= "main"
+      self.mirror_url ||= "http://ftp.us.debian.org/debian/"
+
+      cmd.run(sprintf(
+                "debootstrap --arch=%s --variant=%s --components=%s %s %s %s",
+                arch, variant, components, debian_release, root.to_str, mirror_url
+              ))
       log("Success!")
       return true
     end

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -7,10 +7,10 @@ module Haconiwa
                   :arch, :variant, :components, :debian_release, :mirror_url
 
     def boot!(r)
-      self.root = Pathname.new(r)
-      self.project_name ||= File.basename(root.to_s)
-      if File.directory?(root)
-        log("Directory #{root} already bootstrapped.")
+      self.root = Pathname.new(r.to_s)
+      self.project_name ||= File.basename(root.to_str)
+      if File.directory?(root.to_str)
+        log("Directory #{root.to_str} already bootstrapped. Skip.")
         return true
       end
 

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -1,5 +1,20 @@
 module Haconiwa
   module Cli
+    def self.create(args)
+      # FIXME: to by DRY
+      opt.literal('h', 'help', "Show help")
+      opt.enable_catchall('HACO_FILE', '', 32)
+      e = opt.parse(args)
+
+      if opt['h'].exist?
+        opt.glossary
+        exit
+      end
+
+      get_base(args).create
+    end
+
+
     def self.run(args)
       opt = Argtable.new
       opt.literal('D', 'daemon', "Force the container to be daemon")
@@ -85,6 +100,11 @@ module Haconiwa
     end
 
     private
+
+    def self.get_base(args)
+      script = File.read(args[0])
+      return Kernel.eval(script)
+    end
 
     def self.get_script_and_eval(args)
       script = File.read(args[0])

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -16,6 +16,22 @@ module Haconiwa
       get_base(opt.catchall.values).create(opt['N'].exist?)
     end
 
+    def self.provision(args)
+      opt = Argtable.new
+      opt.string('r', 'run-only', 'OP_NAME[,OP_NAME,...]', "Run only specified provision operations by names(splitted with ,)")
+      opt.literal('h', 'help', "Show help")
+      opt.enable_catchall('HACO_FILE', '', 32)
+      e = opt.parse(args)
+
+      if opt['h'].exist?
+        opt.glossary
+        exit
+      end
+
+      ops = opt['r'].exist? ? opt['r'].value.split(',') : []
+      get_base(opt.catchall.values).do_provision(ops)
+    end
+
     def self.run(args)
       opt = Argtable.new
       opt.literal('D', 'daemon', "Force the container to be daemon")

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -2,6 +2,7 @@ module Haconiwa
   module Cli
     def self.create(args)
       # FIXME: to by DRY
+      opt = Argtable.new
       opt.literal('h', 'help', "Show help")
       opt.enable_catchall('HACO_FILE', '', 32)
       e = opt.parse(args)
@@ -11,7 +12,7 @@ module Haconiwa
         exit
       end
 
-      get_base(args).create
+      get_base(opt.catchall.values).create
     end
 
 

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -3,6 +3,7 @@ module Haconiwa
     def self.create(args)
       # FIXME: to by DRY
       opt = Argtable.new
+      opt.literal('N', 'no-provision', "Bootstrap but no provisioning")
       opt.literal('h', 'help', "Show help")
       opt.enable_catchall('HACO_FILE', '', 32)
       e = opt.parse(args)
@@ -12,9 +13,8 @@ module Haconiwa
         exit
       end
 
-      get_base(opt.catchall.values).create
+      get_base(opt.catchall.values).create(opt['N'].exist?)
     end
-
 
     def self.run(args)
       opt = Argtable.new

--- a/mrblib/haconiwa/provision.rb
+++ b/mrblib/haconiwa/provision.rb
@@ -1,0 +1,63 @@
+module Haconiwa
+  class Provision
+    def initialize
+    end
+    attr_accessor :root, :strategy, :extra_bind # TODO
+    attr_reader   :shell
+
+    def shell=(shell)
+      self.strategy = "shell"
+      @shell = shell
+    end
+
+    def provision!(r)
+      self.root = Pathname.new(r.to_s)
+
+      p = self
+      pid = Process.fork do
+        p.chroot_into(p.root)
+
+        case strategy = p.strategy
+        when "shell"
+          p.provision_with_shell
+        else
+          raise "Unsupported: #{strategy}"
+        end
+      end
+      pid, s = *Process.waitpid2(pid)
+
+      if s.success?
+        log "Success!"
+        return true
+      else
+        log "Provisioning failed: #{s.inspect}!"
+        return false
+      end
+    end
+
+    def provision_with_shell
+      cmd = RunCmd.new("provison.shell")
+
+      log("Start provisioning with shell script...")
+      cmd.run_with_input("/bin/bash -xe", self.shell)
+    end
+
+    def chroot_into(root)
+      m = ::Mount.new
+      ::Namespace.unshare ::Namespace::CLONE_NEWNS
+
+      m.make_private "/"
+      Dir.chdir root
+      Dir.chroot root
+      m.mount "proc",     "/proc", type: "proc"
+      m.mount "devtmpfs", "/dev",  type: "devtmpfs"
+      m.mount "sysfs",    "/sys",  type: "sysfs"
+      m.mount "tmpfs",    "/tmp",  type: "tmpfs"
+    end
+
+    private
+    def log(msg)
+      $stderr.puts msg.green
+    end
+  end
+end

--- a/mrblib/haconiwa/provision.rb
+++ b/mrblib/haconiwa/provision.rb
@@ -3,8 +3,8 @@ module Haconiwa
     def initialize
       @ops = []
     end
-    attr_accessor :root, :extra_bind # TODO
-    attr_reader   :ops
+    attr_accessor :root, :ops,
+                  :extra_bind # TODO
 
     class ProvisionOps
       def initialize(strategy, name, body)
@@ -19,6 +19,12 @@ module Haconiwa
       name = options.delete(:name)
       name ||= "shell-#{ops.size + 1}"
       ops << ProvisionOps.new("shell", name, shell)
+    end
+
+    def select_ops(selected_ops)
+      self.ops = ops.select do |op|
+        selected_ops.include? op.name
+      end
     end
 
     def provision!(r)

--- a/mrblib/haconiwa/version.rb
+++ b/mrblib/haconiwa/version.rb
@@ -1,3 +1,3 @@
 module Haconiwa
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/mrblib/vendor/minipathname.rb
+++ b/mrblib/vendor/minipathname.rb
@@ -1,6 +1,6 @@
 class Pathname
   def initialize(path)
-    @path = path
+    @path = clean_slashes(path.to_s)
   end
 
   def join(*paths)

--- a/mrblib/vendor/run_cmd.rb
+++ b/mrblib/vendor/run_cmd.rb
@@ -1,0 +1,51 @@
+class RunCmd
+  def initialize(tag)
+    @tag = tag
+  end
+
+  def run(cmd)
+    r, sout = IO.pipe
+    pid = Process.fork do
+      p = Procutil.system4 cmd, nil, sout, sout
+      sout.close
+      exit p.exitstatus
+    end
+    sout.close
+
+    while(l = r.readline rescue false)
+      puts "[#{@tag}]:\t#{l.chomp.cyan}"
+    end
+    waitcommand(pid, cmd)
+  end
+
+  def run_with_input(cmd, input_data)
+    r, sout = IO.pipe
+    sin, w = IO.pipe
+    w.write input_data
+    w.close
+
+    pid = Process.fork do
+      p = Procutil.system4 cmd, sin, sout, sout
+      sout.close
+      exit p.exitstatus
+    end
+    sout.close
+
+    while(l = r.readline rescue false)
+      puts "[#{@tag}]:\t#{l.chomp.cyan}"
+    end
+    waitcommand(pid, cmd)
+  end
+
+  private
+  def waitcommand(pid, cmd)
+    pid, status = *Process.waitpid2(pid)
+    if status.success?
+      $stderr.puts "Command success: #{cmd} exited #{status.exitstatus}"
+    else
+      raise "Command failed...: #{cmd} exited #{status.exitstatus}"
+    end
+
+    return [pid, status]
+  end
+end

--- a/sample/chroot.haco
+++ b/sample/chroot.haco
@@ -3,7 +3,14 @@ Haconiwa.define do |config|
   config.name = "chroot001" # to be hostname
   config.init_command = "/bin/sh" # to be first process
 
-  root = Pathname.new("/var/haconiwa/root")
+  root = Pathname.new("/var/lib/haconiwa-chroot001")
+
+  config.bootstrap do |b|
+    b.project_name = "chroot-boot001"
+    b.strategy = "lxc"
+    b.os_type = "alpine"
+  end
+
   config.add_mount_point "/var/lib/haconiwa", to: root, readonly: true
   config.add_mount_point "/lib64", to: root.join("lib64"), readonly: true
   config.add_mount_point "/usr/bin", to: root.join("usr/bin"), readonly: true

--- a/sample/chroot.haco
+++ b/sample/chroot.haco
@@ -11,9 +11,9 @@ Haconiwa.define do |config|
     b.os_type = "alpine"
   end
 
-  config.add_mount_point "/var/lib/haconiwa", to: root, readonly: true
-  config.add_mount_point "/lib64", to: root.join("lib64"), readonly: true
-  config.add_mount_point "/usr/bin", to: root.join("usr/bin"), readonly: true
+  config.add_mount_point root, to: root, readonly: true
+  #config.add_mount_point "/lib64", to: root.join("lib64"), readonly: true
+  #config.add_mount_point "/usr/bin", to: root.join("usr/bin"), readonly: true
   config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
   config.add_mount_point "/var/haconiwa/user_homes/", to: root.join("home/haconiwa")
   config.mount_independent_procfs

--- a/sample/debootstrap.haco
+++ b/sample/debootstrap.haco
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 Haconiwa.define do |config|
   config.name = "deb001" # to be hostname
-  config.init_command = "/bin/sh" # to be first process
+  config.init_command = ["/usr/sbin/sshd", "-D"] # to be first process
+  config.daemonize!
 
   root = Pathname.new("/var/lib/haconiwa-deb001")
 
@@ -16,14 +17,19 @@ Haconiwa.define do |config|
     p.shell = <<-SHELL
 export DEBIAN_FRONTEND=nonintaractive
 apt-get -y update
-apt-get -y install git
-adduser haconiwa-op --disabled-password --gecos ""
+apt-get -y install git openssh-server
+
+adduser haconiwa-op --disabled-password --gecos "" || true
+echo 'haconiwa-op:haconiwa' | chpasswd
+
+sed -i 's/Port.*/Port 2222/' etc/ssh/sshd_config
     SHELL
   end
 
   config.add_mount_point root, to: root
   config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
   config.add_mount_point "devtmpfs", to: root.join("dev"), fs: "devtmpfs"
+  config.add_mount_point "devpts", to: root.join("dev/pts"), fs: "devpts"
   config.add_mount_point "sysfs", to: root.join("sys"), fs: "sysfs"
   config.mount_independent_procfs
   config.chroot_to root

--- a/sample/debootstrap.haco
+++ b/sample/debootstrap.haco
@@ -12,6 +12,15 @@ Haconiwa.define do |config|
     b.mirror_url = "http://ftp.jp.debian.org/debian/"
   end
 
+  config.provision do |p|
+    p.shell = <<-SHELL
+export DEBIAN_FRONTEND=nonintaractive
+apt-get -y update
+apt-get -y install git
+adduser haconiwa-op --disabled-password --gecos ""
+    SHELL
+  end
+
   config.add_mount_point root, to: root
   config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
   config.add_mount_point "devtmpfs", to: root.join("dev"), fs: "devtmpfs"

--- a/sample/debootstrap.haco
+++ b/sample/debootstrap.haco
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  config.name = "deb001" # to be hostname
+  config.init_command = "/bin/sh" # to be first process
+
+  root = Pathname.new("/var/lib/haconiwa-deb001")
+
+  config.bootstrap do |b|
+    b.strategy = "debootstrap"
+    b.variant = "minbase"
+    b.debian_release = "jessie"
+    b.mirror_url = "http://ftp.jp.debian.org/debian/"
+  end
+
+  config.add_mount_point root, to: root
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+  config.add_mount_point "devtmpfs", to: root.join("dev"), fs: "devtmpfs"
+  config.add_mount_point "sysfs", to: root.join("sys"), fs: "sysfs"
+  config.mount_independent_procfs
+  config.chroot_to root
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+end

--- a/sample/debootstrap.haco
+++ b/sample/debootstrap.haco
@@ -14,15 +14,19 @@ Haconiwa.define do |config|
   end
 
   config.provision do |p|
-    p.shell = <<-SHELL
+    p.run_shell <<-SHELL
 export DEBIAN_FRONTEND=nonintaractive
+export LANG=C
 apt-get -y update
 apt-get -y install git openssh-server
+sed -i 's/Port.*/Port 2222/' etc/ssh/sshd_config
+    SHELL
 
+    p.run_shell <<-SHELL, name: "setup-user"
+export DEBIAN_FRONTEND=nonintaractive
+export LANG=C
 adduser haconiwa-op --disabled-password --gecos "" || true
 echo 'haconiwa-op:haconiwa' | chpasswd
-
-sed -i 's/Port.*/Port 2222/' etc/ssh/sshd_config
     SHELL
   end
 


### PR DESCRIPTION
```ruby
Haconiwa.define do |config|
  config.bootstrap do |b|
    b.project_name = "chroot-boot001"
    b.strategy = "lxc"
    b.os_type = "alpine"
  end

  config.provision do |p|
    p.run_shell <<-SHELL
export DEBIAN_FRONTEND=nonintaractive
export LANG=C
apt-get -y update
apt-get -y install git openssh-server
sed -i 's/Port.*/Port 2222/' etc/ssh/sshd_config
    SHELL

    p.run_shell <<-SHELL, name: "setup-user"
export DEBIAN_FRONTEND=nonintaractive
export LANG=C
adduser haconiwa-op --disabled-password --gecos "" || true
echo 'haconiwa-op:haconiwa' | chpasswd
    SHELL
  end
end
```

`bootstrap` supports lxc, debootstrap (docker soon...?)

`provision` ... supports shell, or ansible looks good? (chef/itamae ... I have no idea bridging ruby and mruby)