### PR TITLE
Container dependent filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Haconiwa::Base.define do |config|
 
   config.add_mount_point "/var/another/root/etc", to: "/var/your_rootfs/etc", readonly: true
   config.add_mount_point "/var/another/root/home", to: "/var/your_rootfs/home"
-  config.mount_independent_procfs
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
   config.chroot_to "/var/your_rootfs"
 
   config.namespace.unshare "ipc"
@@ -138,7 +139,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.capabilities.allow` - Allow capabilities on container root. Setting parameters other than `:all` should make this acts as whitelist
 * `config.capabilities.drop` - Drop capabilities of container root. Default to act as blacklist
 * `config.add_mount_point` - Add the mount point odf container
-* `config.mount_independent_procfs` - Mount the independent /proc directory in the container. Useful if `"pid"` is unshared
+* `config.mount_independent` - Mount the independent filesystems: `"procfs", "sysfs", "devtmpfs", "devpts" and "shm"` in the newborn container. Useful if `"pid"` or `"net"` are unshared
 * `config.chroot_to` - The new chroot root
 * `config.uid=/config.gid=` - The new container's running uid/gid. `groups=` is also respected
 * `config.add_handler` - Define signal handler at supervisor process(not container itself). Available signals are `SIGTTIN/SIGTTOU/SIGUSR1/SIGUSR2`. See [handler example](./sample/cpu.haco).

--- a/mrblib/haconiwa/generator.rb
+++ b/mrblib/haconiwa/generator.rb
@@ -42,8 +42,13 @@ apk add --update bash
   # config.add_mount_point root, to: root, readonly: true
   # config.add_mount_point "/lib64", to: root.join("lib64"), readonly: true
 
-  # This is recommended when PID namespace is unshared:
-  config.mount_independent_procfs
+  # Re-mount specific filesystems under new container namespace
+  # These are recommended when namespaces such as pid and net are unshared:
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
 
   # The namespaces to unshare:
   config.namespace.unshare "mount"

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -218,11 +218,14 @@ module Haconiwa
       end
     end
 
-    def do_chroot(base, remount_procfs=true)
+    def do_chroot(base, init_mount=true)
       Dir.chroot base.filesystem.chroot
       Dir.chdir "/"
-      if remount_procfs && base.filesystem.mount_independent_procfs
-        Mount.new.mount("proc", "/proc", type: "proc")
+      if init_mount
+        m = Mount.new
+        base.filesystem.independent_mount_points.each do |mp|
+          m.mount mp.src, mp.dest, type: mp.fs
+        end
       end
     end
 

--- a/sample/chroot.haco
+++ b/sample/chroot.haco
@@ -16,7 +16,11 @@ Haconiwa.define do |config|
   #config.add_mount_point "/usr/bin", to: root.join("usr/bin"), readonly: true
   config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
   config.add_mount_point "/var/haconiwa/user_homes/", to: root.join("home/haconiwa")
-  config.mount_independent_procfs
+  config.mount_independent("procfs")
+  config.mount_independent("sysfs")
+  config.mount_independent("devtmpfs")
+  config.mount_independent("devpts")
+  config.mount_independent("shm")
   config.chroot_to root
 
   config.namespace.unshare "mount"


### PR DESCRIPTION
* Deprecate `mount_independent_procfs`
* Add some internal mounter, following [OCI spec](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-filesystems) 