### PR TITLE
Implement `haconiwa ps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ e.g. just using `mount` namespace unshared, container with common filesystem, li
 
 Please look into [`sample`](./sample) directory.
 
+### Clustering
+
+#### Container control with etcd
+
+If there is a `/etc/haconiwa.onf.rb` file, as a global config:
+
+```ruby
+Haconiwa.configure do |config|
+  config.etcd_url = "http://localhost:2379/v2"
+end
+```
+
+`haconiwa` cli understands this DSL and uses [etcd](https://coreos.com/etcd/) as a container database backend, with enabled clustering. We recommend to set etcd's server name to host's primary LAN IP(such as: `ETCD_NAME="192.168.0.100"`).
+
+You can run `haconiwa ps` to check container processes (all over the hosts clustered by etcd!).
+
 ### Programming the container world by mruby
 
 e.g.:

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Please look into [`sample`](./sample) directory.
 
 ### Clustering
 
-#### Container control with etcd
+#### Container management with etcd
 
-If there is a `/etc/haconiwa.onf.rb` file, as a global config:
+If there is a `/etc/haconiwa.conf.rb` file like below, as a global config:
 
 ```ruby
 Haconiwa.configure do |config|

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -23,6 +23,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-capability', :github => 'matsumoto-r/mruby-capability'
   spec.add_dependency 'mruby-resource'  , :github => 'harasou/mruby-resource'
   spec.add_dependency 'mruby-dir'       , :github => 'iij/mruby-dir' # with Dir#chroot
+  spec.add_dependency 'mruby-socket'    , :github => 'iij/mruby-socket'
   spec.add_dependency 'mruby-procutil'  , :github => 'haconiwa/mruby-procutil'
   spec.add_dependency 'mruby-exec'      , :github => 'haconiwa/mruby-exec'
   spec.add_dependency 'mruby-namespace' , :github => 'haconiwa/mruby-namespace'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -31,6 +31,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-process-sys' , :github => 'haconiwa/mruby-process-sys'
   spec.add_dependency 'mruby-argtable'  , :github => 'udzura/mruby-argtable', :branch => 'static-link-argtable3'
   spec.add_dependency 'mruby-signal'    , :github => 'ksss/mruby-signal'
+  spec.add_dependency 'mruby-etcd'      , :github => 'udzura/mruby-etcd'
 
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -24,6 +24,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-resource'  , :github => 'harasou/mruby-resource'
   spec.add_dependency 'mruby-dir'       , :github => 'iij/mruby-dir' # with Dir#chroot
   spec.add_dependency 'mruby-socket'    , :github => 'iij/mruby-socket'
+  spec.add_dependency 'mruby-regexp-pcre', :github => 'iij/mruby-regexp-pcre'
   spec.add_dependency 'mruby-procutil'  , :github => 'haconiwa/mruby-procutil'
   spec.add_dependency 'mruby-exec'      , :github => 'haconiwa/mruby-exec'
   spec.add_dependency 'mruby-namespace' , :github => 'haconiwa/mruby-namespace'

--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -17,6 +17,8 @@ def __main__(argv)
     Haconiwa::Cli.attach(argv)
   when "kill"
     Haconiwa::Cli.kill(argv)
+  when "ps", "list"
+    Haconiwa::Cli.ps(argv)
   else
     puts <<-USAGE
 haconiwa - The MRuby on Container
@@ -27,6 +29,7 @@ commands:
     start     - run the container
     attach    - attach to existing container
     kill      - kill the running container
+    ps        - list running containers (across the clusterd hosts, etcd needed)
     version   - show version
     revisions - show mgem/mruby revisions which haconiwa bin uses
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -10,7 +10,8 @@ module Haconiwa
                   :attached_capabilities,
                   :signal_handler,
                   :pid,
-                  :supervisor_pid
+                  :supervisor_pid,
+                  :created_at
 
     attr_reader   :init_command,
                   :uid,

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -11,7 +11,8 @@ module Haconiwa
                   :signal_handler,
                   :pid,
                   :supervisor_pid,
-                  :created_at
+                  :created_at,
+                  :etcd_name
 
     attr_reader   :init_command,
                   :uid,
@@ -166,6 +167,7 @@ module Haconiwa
     def to_container_json
       {
         name: self.name,
+        etcd_name: self.etcd_name,
         root: self.filesystem.chroot,
         command: self.init_command.join(" "),
         created_at: self.created_at,
@@ -174,6 +176,10 @@ module Haconiwa
         pid: self.pid,
         supervisor_pid: self.supervisor_pid,
       }.to_json
+    end
+
+    def etcd_key
+      "haconiwa.mruby.org/#{etcd_name}/#{name}"
     end
 
     def validate_non_nil(obj, msg)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -9,7 +9,8 @@ module Haconiwa
                   :capabilities,
                   :attached_capabilities,
                   :signal_handler,
-                  :pid
+                  :pid,
+                  :supervisor_pid
 
     attr_reader   :init_command,
                   :uid,
@@ -159,6 +160,19 @@ module Haconiwa
 
     def daemon?
       !! @daemon
+    end
+
+    def to_container_json
+      {
+        name: self.name,
+        root: self.filesystem.chroot,
+        command: self.init_command.join(" "),
+        created_at: self.created_at,
+        status: "running", # TODO: support status
+        metadata: {dummy: "dummy"}, # TODO: support metadata/tagging
+        pid: self.pid,
+        supervisor_pid: self.supervisor_pid,
+      }.to_json
     end
 
     def validate_non_nil(obj, msg)

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -73,7 +73,7 @@ module Haconiwa
         exit
       end
 
-      Haconiwa::Process.new.show_list
+      Haconiwa::ProcessList.new.show
     end
 
     def self.kill(args)

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -62,9 +62,18 @@ module Haconiwa
       base.attach(*exe)
     end
 
-    def self.ps
+    def self.ps(args)
       load_global_config
-      p Haconiwa.config.etcd_available?
+      opt = Argtable.new
+      opt.literal('h', 'help', "Show help")
+      opt.parse(args)
+
+      if opt['h'].exist?
+        opt.glossary
+        exit
+      end
+
+      Haconiwa::Process.new.show_list
     end
 
     def self.kill(args)

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -30,6 +30,8 @@ module Haconiwa
     end
 
     def self.run(args)
+      load_global_config
+
       opt = parse_opts(args, 'HACO_FILE [-- COMMAND...]') do |o|
         o.literal('D', 'daemon', "Force the container to be daemon")
       end

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -60,6 +60,11 @@ module Haconiwa
       base.attach(*exe)
     end
 
+    def self.ps
+      load_global_config
+      p Haconiwa.config.etcd_available?
+    end
+
     def self.kill(args)
       opt = parse_opts(args) do |o|
         o.integer('t', 'target', 'PID', "Container's PID to kill.")
@@ -79,6 +84,14 @@ module Haconiwa
     end
 
     private
+
+    GLOBAL_CONFIG_FILE = "/etc/haconiwa.conf.rb"
+    def self.load_global_config
+      # The hook of load global config
+      if File.exist?(GLOBAL_CONFIG_FILE)
+        eval(File.read GLOBAL_CONFIG_FILE)
+      end
+    end
 
     def self.parse_opts(args, hacofile_opt='HACO_FILE', &b)
       opt = Argtable.new

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -68,6 +68,8 @@ module Haconiwa
     end
 
     def self.kill(args)
+      load_global_config
+
       opt = parse_opts(args) do |o|
         o.integer('t', 'target', 'PID', "Container's PID to kill.")
         o.string('s', 'signal', 'SIGFOO', "Signal name. default to TERM")

--- a/mrblib/haconiwa/global_config.rb
+++ b/mrblib/haconiwa/global_config.rb
@@ -1,0 +1,25 @@
+module Haconiwa
+  class GlobalConfig
+    attr_accessor :etcd_url
+
+    def etcd_available?
+      # WIP
+    end
+
+    class << self
+      def instance
+        @@__instance__ ||= new
+      end
+    end
+  end
+
+  class << self
+    def config
+      if block_given?
+        yield ::Haconiwa::GlobalConfig.instance
+      end
+      ::Haconiwa::GlobalConfig.instance
+    end
+    alias configure config
+  end
+end

--- a/mrblib/haconiwa/global_config.rb
+++ b/mrblib/haconiwa/global_config.rb
@@ -8,7 +8,12 @@ module Haconiwa
       _url = etcd_url.gsub("/v2", "").split(':')
       host = _url[-2].gsub("/", "")
       port = _url[-1].to_i
-      !!(TCPSocket.open(host, port)) rescue false
+      begin
+        !!(TCPSocket.open(host, port))
+      rescue
+        STDERR.puts "[Warn] etcd_url=#{etcd_url} at /etc/haconiwa.conf.rb configured, but seems to be unavailable"
+        false
+      end
     end
 
     class << self

--- a/mrblib/haconiwa/global_config.rb
+++ b/mrblib/haconiwa/global_config.rb
@@ -5,9 +5,9 @@ module Haconiwa
     def etcd_available?
       return false unless etcd_url
 
-      _url = etcd_url.split(':')
-      host = _url[-2].gsub("/", "")
-      port = _url[-1].to_i
+      _url = etcd_url.gsub("/v2", "").split(':')
+      host = url[-2].gsub("/", "")
+      port = url[-1].to_i
       !!(TCPSocket.open(host, port)) rescue false
     end
 

--- a/mrblib/haconiwa/global_config.rb
+++ b/mrblib/haconiwa/global_config.rb
@@ -6,8 +6,8 @@ module Haconiwa
       return false unless etcd_url
 
       _url = etcd_url.gsub("/v2", "").split(':')
-      host = url[-2].gsub("/", "")
-      port = url[-1].to_i
+      host = _url[-2].gsub("/", "")
+      port = _url[-1].to_i
       !!(TCPSocket.open(host, port)) rescue false
     end
 

--- a/mrblib/haconiwa/global_config.rb
+++ b/mrblib/haconiwa/global_config.rb
@@ -3,7 +3,12 @@ module Haconiwa
     attr_accessor :etcd_url
 
     def etcd_available?
-      # WIP
+      return false unless etcd_url
+
+      _url = etcd_url.split(':')
+      host = _url[-2].gsub("/", "")
+      port = _url[-1].to_i
+      !!(TCPSocket.open(host, port)) rescue false
     end
 
     class << self

--- a/mrblib/haconiwa/process.rb
+++ b/mrblib/haconiwa/process.rb
@@ -1,5 +1,5 @@
 module Haconiwa
-  class Process
+  class ProcessList
     def initialize
       if Haconiwa.config.etcd_available?
         @etcd = Etcd::Client.new(Haconiwa.config.etcd_url)
@@ -8,9 +8,9 @@ module Haconiwa
       end
     end
 
-    LIST_FORMAT = "%-16s\t%-16s\t%-16s\t%-16s\t%-30s\t%-8s\t%5s\t%5s"
+    LIST_FORMAT = "%-16s\t%-16s\t%-16s\t%-16s\t%-30s\t%-8s\t%-5s\t%-5s"
 
-    def show_list
+    def show
       puts sprintf(LIST_FORMAT, *(%w(NAME HOST ROOTFS COMMAND CREATED_AT STATUS PID SPID)))
       puts containers.map{|c| sprintf(LIST_FORMAT, *to_array(c)) }.join("\n")
     end

--- a/mrblib/haconiwa/process.rb
+++ b/mrblib/haconiwa/process.rb
@@ -1,0 +1,49 @@
+module Haconiwa
+  class Process
+    def initialize
+      if Haconiwa.config.etcd_available?
+        @etcd = Etcd::Client.new(Haconiwa.config.etcd_url)
+      else
+        raise "`haconiwa ps' requires etcd available"
+      end
+    end
+
+    LIST_FORMAT = "%-16s\t%-16s\t%-16s\t%-16s\t%-30s\t%-8s\t%5s\t%5s"
+
+    def show_list
+      puts sprintf(LIST_FORMAT, *(%w(NAME HOST ROOTFS COMMAND CREATED_AT STATUS PID SPID)))
+      puts containers.map{|c| sprintf(LIST_FORMAT, *to_array(c)) }.join("\n")
+    end
+
+    def containers
+      c = []
+      hosts = @etcd.list("haconiwa.mruby.org")
+      hosts.each do |host|
+        if host["dir"]
+          begin
+            key = host["key"].sub(/^\//, '')
+            @etcd.list(key).each do |container|
+              c << JSON.parse(container["value"])
+            end
+          rescue
+            STDERR.puts "[Warn] Invalid key #{key}. skip"
+          end
+        end
+      end
+      c
+    end
+
+    def to_array(json)
+      [
+        json["name"],
+        json["etcd_name"],
+        json["root"],
+        json["command"],
+        json["created_at"],
+        json["status"],
+        json["pid"],
+        json["supervisor_pid"],
+      ]
+    end
+  end
+end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -128,14 +128,14 @@ module Haconiwa
         w.close
         pid = r.read
 
-        base.created_at = Time.now
-        base.pid = pid
-        base.supervisor_pid = ppid
+        @base.created_at = Time.now
+        @base.pid = pid.to_i
+        @base.supervisor_pid = ppid
         if @etcd
-          @etcd.set "haconinwa.mruby.org/localhost/#{base.name}", base.to_container_json
+          @etcd.put "haconinwa.mruby.org/localhost/#{@base.name}", @base.to_container_json
         end
 
-        puts "Container successfullly up. PID={container: #{pid.chomp}, supervisor: #{ppid}}"
+        puts "Container successfullly up. PID={container: #{@base.pid}, supervisor: #{@base.supervisor_pid}}"
       else
         b.call(@base, nil)
       end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -41,6 +41,9 @@ module Haconiwa
 
         pid, status = Process.waitpid2 pid
         cleanup_cgroup(base)
+        if @etcd
+          @etcd.delete base.etcd_key
+        end
         File.unlink base.container_pid_file
         if status.success?
           puts "Container successfullly exited: #{status.inspect}"
@@ -107,9 +110,6 @@ module Haconiwa
       10.times do
         sleep 0.1
         unless File.exist?(@base.container_pid_file)
-          if @etcd
-            @etcd.delete @base.etcd_key
-          end
           puts "Kill success"
           Process.exit 0
         end


### PR DESCRIPTION
The future:

```console
$ haconiwa ps
NAME        COMMAND       CREATED_AT                   STATUS  META
haconiwa001 /sbin/init    Mon Aug 22 15:00:01 JST 2016 running foo=bar
haconiwa002 /sbin/sshd -D Mon Aug 22 15:30:46 JST 2016 running foo=buz
```

* If file `/etc/haconiwa.conf.rb` exists, then the global config is available.
* If etcd is available, Haconiwa registers container's informations to etcd. `haconiwa ps` just use this.