### PR TITLE
Override init_command from command line arguments

### DIFF
--- a/bintest/walkthrough.rb
+++ b/bintest/walkthrough.rb
@@ -52,6 +52,10 @@ assert('walkthrough') do
     assert_true File.directory? "#{HACONIWA_TMP_ROOT}/root"
     assert_true (/^3\.\d\.\d$/).match(File.read("#{HACONIWA_TMP_ROOT}/etc/alpine-release"))
 
+    output, status = run_haconiwa "run", "-T", haconame, "--", "/usr/bin/uptime"
+    assert_true status.success?, "Process did not exit cleanly: run"
+    assert_include output, "load average"
+
     output, status = run_haconiwa "run", haconame
     assert_true status.success?, "Process did not exit cleanly: run"
     processes = `ps axf`

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -160,6 +160,10 @@ module Haconiwa
       @daemon = true
     end
 
+    def cancel_daemonize!
+      @daemon = false
+    end
+
     def daemon?
       !! @daemon
     end

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -39,10 +39,12 @@ module Haconiwa
 
       opt = parse_opts(args, 'HACO_FILE [-- COMMAND...]') do |o|
         o.literal('D', 'daemon', "Force the container to be daemon")
+        o.literal('T', 'no-daemon', "Force the container not to be daemon, stuck in tty")
       end
 
       base, init = get_script_and_eval(opt.catchall.values)
       base.daemonize! if opt['D'].exist?
+      base.cancel_daemonize! if opt['T'].exist?
       base.run(*init)
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -15,6 +15,9 @@ module Haconiwa
       if File.exist? @base.container_pid_file
         raise "PID file #{@base.container_pid_file} exists. You may be creating the container with existing name #{@base.name}!"
       end
+      unless init_command.empty?
+        @base.init_command = init_command
+      end
 
       wrap_daemonize do |base, notifier|
         jail_pid(base)


### PR DESCRIPTION
```bash
# init_command = '/bin/bash' in foo.haco
haconiwa run foo.haco -- /bin/sleep 100
```

Ignored unintendedly, so fixed