### PR TITLE
Implement `haconiwa watch`

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -7,7 +7,7 @@ MRuby::Build.new do |conf|
   toolchain :gcc
 
   conf.enable_bintest
-  #conf.enable_debug
+  conf.enable_debug
   conf.enable_test
 
   gem_config(conf)

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -36,7 +36,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-etcd'      , :github => 'udzura/mruby-etcd'
 
   spec.add_dependency 'mruby-uv'        , :github => 'mattn/mruby-uv'
-  spec.add_dependency 'mruby-mutex'     , :github => 'matsumoto-r/mruby-mutex'
+  #spec.add_dependency 'mruby-mutex'     , :github => 'matsumoto-r/mruby-mutex'
 
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -36,6 +36,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-etcd'      , :github => 'udzura/mruby-etcd'
 
   spec.add_dependency 'mruby-uv'        , :github => 'mattn/mruby-uv'
+  spec.add_dependency 'mruby-mutex'     , :github => 'matsumoto-r/mruby-mutex'
 
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -35,6 +35,8 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-signal'    , :github => 'ksss/mruby-signal'
   spec.add_dependency 'mruby-etcd'      , :github => 'udzura/mruby-etcd'
 
+  spec.add_dependency 'mruby-uv'        , :github => 'mattn/mruby-uv'
+
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do
       f = open(DEFS_FILE, 'w')

--- a/mrblib/haconiwa.rb
+++ b/mrblib/haconiwa.rb
@@ -19,6 +19,8 @@ def __main__(argv)
     Haconiwa::Cli.kill(argv)
   when "ps", "list"
     Haconiwa::Cli.ps(argv)
+  when "watch"
+    Haconiwa::Cli.watch(argv)
   else
     puts <<-USAGE
 haconiwa - The MRuby on Container
@@ -30,6 +32,7 @@ commands:
     attach    - attach to existing container
     kill      - kill the running container
     ps        - list running containers (across the clusterd hosts, etcd needed)
+    watch     - (experimental) watch the cluster status and set hooks via mruby file
     version   - show version
     revisions - show mgem/mruby revisions which haconiwa bin uses
 

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -103,6 +103,7 @@ module Haconiwa
       opt = parse_opts(args, 'WATCH_FILE') do |o|
       end
 
+      watch = Haconiwa::Watch.from_file(opt.catchall.value(0))
       Haconiwa::Watch.run
     end
 

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -104,7 +104,7 @@ module Haconiwa
       end
 
       watch = Haconiwa::Watch.from_file(opt.catchall.value(0))
-      Haconiwa::Watch.run
+      Haconiwa::Watch.run(watch)
     end
 
     def self.revisions

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -98,6 +98,14 @@ module Haconiwa
       base.kill(signame)
     end
 
+    def self.watch(args)
+      load_global_config
+      opt = parse_opts(args, 'WATCH_FILE') do |o|
+      end
+
+      Haconiwa::Watch.run
+    end
+
     def self.revisions
       puts "mgem and mruby revisions:"
       puts "--------"

--- a/mrblib/haconiwa/watch.rb
+++ b/mrblib/haconiwa/watch.rb
@@ -107,9 +107,12 @@ module Haconiwa
             end
           end
 
+          wi = nil
+          wi_param = {}
           loop do
-            ret = etcd.wait(event.watch_key, true)
+            ret = etcd.wait(event.watch_key, true, wi_param)
             puts "Received: #{ret.inspect}"
+            wi = ret["node"]["modifiedIndex"] rescue 0
             hook = UV::Async.new {|_|
               # TODO: race condition
               if event.hook
@@ -117,6 +120,7 @@ module Haconiwa
               end
             }
             hook.send
+            wi_param = {wait_index: (wi + 1)}
           end
         }
         puts "Registered: #{event.name}"

--- a/mrblib/haconiwa/watch.rb
+++ b/mrblib/haconiwa/watch.rb
@@ -1,0 +1,24 @@
+module Haconiwa
+  class Watch
+    def self.run
+      unless Haconiwa.config.etcd_available?
+        raise "`haconiwa watch' requires etcd available"
+      end
+      p = UV::Prepare.new()
+
+      a = UV::Async.new {|_|
+        etcd = Etcd::Client.new(Haconiwa.config.etcd_url)
+        loop do
+          ret = etcd.wait("haconiwa.mruby.org", true)
+          puts "Changed: #{ret.inspect}"
+        end
+      }
+
+      p.start {|x|
+        a.send
+      }
+
+      UV::run()
+    end
+  end
+end

--- a/mrblib/vendor/uuid.rb
+++ b/mrblib/vendor/uuid.rb
@@ -3,6 +3,19 @@ module UUID
     Kernel.srand(Time.now.to_i ^ Process.pid)
   end
 
+  def self.secure_random(range=nil)
+    case range
+    when NilClass
+      b = File.read("/dev/urandom", 1).bytes.first + 1
+      1 - (b / 256.0)
+    when Range
+      r = range.to_a
+      r[secure_random(r.size)]
+    else
+      (range * secure_random).floor
+    end
+  end
+
   def self.uuid(fmt="%04x%04x-%04x-%04x-%04x-%04x%04x%04x")
     s = []
     8.times { s << rand(256 * 256) }

--- a/sample/sleeper001.haco
+++ b/sample/sleeper001.haco
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  suffix = UUID.secure_uuid("%x%x")
+
+  # The container name and container's hostname:
+  config.name = "haconiwa-#{suffix}"
+  # The first process when invoking haconiwa run:
+  config.init_command = ["/bin/sleep", (ENV['SLEEP'] || (30 + (UUID.secure_uuid("%d").to_i / 256).floor).to_s)]
+  # If your first process is a daemon, please explicitly daemonize by:
+  config.daemonize!
+
+  # The rootfs location on your host OS
+  # Pathname class is useful:
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.chroot_to root
+
+  # The bootstrap process...
+  # Choose lxc or debootstrap:
+  config.bootstrap do |b|
+    b.strategy = "lxc"
+    b.os_type  = "alpine"
+
+    # b.strategy = "debootstrap"
+    # b.variant = "minbase"
+    # b.debian_release = "jessie"
+  end
+  # Check that the required binary is installed(lxc-create / debootstrap)
+
+  # The provisioning process...
+  # You can declare run_shell step by step:
+  config.provision do |p|
+    p.run_shell <<-SHELL
+apk add --update bash
+    SHELL
+  end
+
+  # mount point configuration:
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+
+  # more mount point configuration example:
+  # config.add_mount_point root, to: root, readonly: true
+  # config.add_mount_point "/lib64", to: root.join("lib64"), readonly: true
+
+  # Re-mount specific filesystems under new container namespace
+  # These are recommended when namespaces such as pid and net are unshared:
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  # The namespaces to unshare:
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  # You can use existing namespace via symlink file. e.g.:
+  # config.namespace.enter "net", via: "/var/run/netns/sample001"
+
+  # The cgroup configuration example:
+  # config.cgroup["cpu.cfs_period_us"] = 100000
+  # config.cgroup["cpu.cfs_quota_us"]  =  30000
+
+  # The linux capability blacklist
+  # These are useful when you run container as root:
+  # config.capabilities.drop "cap_sys_time"
+  # config.capabilities.drop "cap_kill"
+
+  # When you use whitelist capability, set:
+  # config.capabilities.allow "cap_sys_admin"
+
+  # Specify uid/gid who owns container process:
+  # config.uid = "vagrant"
+  # config.gid = "vagrant"
+
+  # The resource limit:
+  # config.resource.set_limit(:CPU, 10 * 60)
+  # config.resource.set_limit(:NOFILE, 30)
+
+  # More examples and informations, please visit:
+  # https://github.com/haconiwa/haconiwa/tree/master/sample
+  # Enjoy your own container!
+end

--- a/sample/watch-sample.rb
+++ b/sample/watch-sample.rb
@@ -1,0 +1,6 @@
+Haconiwa.watch do |config|
+  config.watch :cluster do |event|
+    puts "Receive!" + event.raw_resp.inspect
+    puts "Receive!" + event.cluster.inspect
+  end
+end

--- a/sample/watch-sample.rb
+++ b/sample/watch-sample.rb
@@ -1,6 +1,11 @@
 Haconiwa.watch do |config|
   config.watch :cluster do |event|
-    puts "Receive!" + event.raw_resp.inspect
-    puts "Receive!" + event.cluster.inspect
+    # puts "Receive!" + event.raw_resp.inspect
+    # puts "Receive!" + event.cluster.inspect
+    if event.cluster.count <= 5
+      (5 - event.cluster.count).times do
+        Haconiwa.spawn "/etc/haconiwa/haco.d/test001.haco"
+      end
+    end
   end
 end

--- a/sample/watch-sample.rb
+++ b/sample/watch-sample.rb
@@ -2,10 +2,9 @@ Haconiwa.watch do |config|
   config.watch :cluster do |event|
     # puts "Receive!" + event.raw_resp.inspect
     # puts "Receive!" + event.cluster.inspect
-    if event.cluster.count <= 5
-      (5 - event.cluster.count).times do
-        Haconiwa.spawn "/etc/haconiwa/haco.d/test001.haco"
-      end
+    if event.cluster.count < 5
+      # Should be spawned 1 by 1
+      Haconiwa.spawn "/etc/haconiwa/haco.d/test001.haco"
     end
   end
 end


### PR DESCRIPTION
## Overview

Prepare small container template:

```ruby
Haconiwa.define do |config|
  suffix = UUID.secure_uuid("%x%x")
  config.name = "haconiwa-#{suffix}"

  config.init_command = ["/bin/sleep", UUID.secure_random(30..60).to_s]
  config.daemonize!

  root = Pathname.new("/var/lib/haconiwa/common")
  config.chroot_to root

  #...
end
```

Prepare watch.rb file:

```ruby
Haconiwa.watch do |config|
  config.watch :cluster do |event|
    if event.cluster.count < 5
      # Should be spawned 1 by 1
      Haconiwa.spawn "/etc/haconiwa/haco.d/test001.haco"
    end
  end
end
```

Run:

```console
$ haconiwa watch watch.rb
...
```

Then container count will be kept to 5, replacing container processes:

```console
$ haconiwa ps
NAME                    HOST                    ROOTFS                          COMMAND                 CREATED_AT                      STATUS          PID     SPID 
haconiwa-31f4636d       192.168.98.200          /var/lib/haconiwa/8cfccb3d      /bin/sleep 32 Mon Aug 29 12:11:36 2016        running         5756    5755 
haconiwa-5e2bca1        192.168.98.200          /var/lib/haconiwa/8cfccb3d      /bin/sleep 40  Mon Aug 29 12:12:40 2016        running         5803    5802 
haconiwa-6e3f4db1       192.168.98.200          /var/lib/haconiwa/8cfccb3d      /bin/sleep 55 Mon Aug 29 12:12:16 2016        running         5784    5783 
haconiwa-bcf346a        192.168.98.200          /var/lib/haconiwa/8cfccb3d      /bin/sleep 48          Mon Aug 29 21:12:50 2016        running         5807    5806 
haconiwa-56ff7df        192.168.98.200          /var/lib/haconiwa/8cfccb3d      /bin/sleep 36           Mon Aug 29 12:13:28 2016        running         5827    5826 
```