### PR TITLE
Fix a FD leak

### DIFF
--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -129,11 +129,13 @@ module Haconiwa
         r, w = IO.pipe
         ppid = Process.fork do
           # TODO: logging
+          r.close
           Procutil.daemon_fd_reopen
           b.call(@base, w)
         end
         w.close
         pid = r.read
+        r.close
 
         @base.created_at = Time.now
         @base.pid = pid.to_i


### PR DESCRIPTION
Close a remaining pipe in supervisor process:

```
[vagrant@udzura haconiwa]$ sudo haconiwa run /etc/haconiwa/haco.d/test001.haco
Container successfully up. PID={container: 16413, supervisor: 16412}
[vagrant@udzura haconiwa]$ sudo ls -l /proc/16412/fd
合計 0
lr-x------ 1 root root 64  8月 30 12:24 0 -> /dev/null
l-wx------ 1 root root 64  8月 30 12:24 1 -> /dev/null
l-wx------ 1 root root 64  8月 30 12:24 2 -> /dev/null
lrwx------ 1 root root 64  8月 30 12:24 3 -> socket:[437006]
lrwx------ 1 root root 64  8月 30 12:24 4 -> socket:[437007]
lrwx------ 1 root root 64  8月 30 12:24 5 -> socket:[437008]
lrwx------ 1 root root 64  8月 30 12:24 6 -> socket:[437015]
lrwx------ 1 root root 64  8月 30 12:24 7 -> socket:[437016]
lrwx------ 1 root root 64  8月 30 12:24 8 -> socket:[437017]
lr-x------ 1 root root 64  8月 30 12:24 9 -> pipe:[437021] <- ⚠️
```