### PR TITLE
Support uid/gid mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,9 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/haconi
 
 ## TODOs
 
-* [ ] Support setguid
-* [ ] Support rlimits
 * [ ] Haconiwa DSL compiler
-* [ ] netns attachment
-* [ ] More utilities such as `ps`
-* [ ] Better daemon handling
+* [ ] Networking helpers
+* [ ] P2P containers
 
 ## License
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -355,15 +355,15 @@ module Haconiwa
     end
 
     def to_flag_for_unshare
-      f = to_flag_without_pid
+      f = to_flag_without_pid_and_user
       @ns_to_path.keys.each do |mask|
         f &= (~mask)
       end
       f
     end
 
-    def to_flag_without_pid
-      to_flag & (~(::Namespace::CLONE_NEWPID))
+    def to_flag_without_pid_and_user
+      to_flag & (~(::Namespace::CLONE_NEWPID | ::Namespace::CLONE_NEWUSER))
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -284,6 +284,8 @@ module Haconiwa
     def initialize
       @use_ns = []
       @ns_to_path = {}
+      @uid_mapping = nil
+      @gid_mapping = nil
     end
 
     def unshare(ns)
@@ -306,7 +308,24 @@ module Haconiwa
       unshare(flag)
       @ns_to_path[flag] = path
     end
-    attr_reader :use_pid_ns, :ns_to_path
+
+    def set_uid_mapping(options)
+      unshare "user"
+      if (options.keys & [:min, :max, :options]).size != 3
+        raise("Invalid mapping option: #{options.inspect}")
+      end
+      @uid_mapping = options
+    end
+
+    def set_gid_mapping(options)
+      unshare "user"
+      if (options.keys & [:min, :max, :options]).size != 3
+        raise("Invalid mapping option: #{options.inspect}")
+      end
+      @gid_mapping = options
+    end
+
+    attr_reader :use_pid_ns, :ns_to_path, :uid_mapping, :gid_mapping
 
     def use_netns(name)
       enter("net", "/var/run/netns/#{name}")

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -325,6 +325,10 @@ module Haconiwa
       @gid_mapping = options
     end
 
+    def use_guid_mapping?
+      !!@uid_mapping or !!@gid_mapping
+    end
+
     attr_reader :use_pid_ns, :ns_to_path, :uid_mapping, :gid_mapping
 
     def use_netns(name)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -311,7 +311,7 @@ module Haconiwa
 
     def set_uid_mapping(options)
       unshare "user"
-      if (options.keys & [:min, :max, :options]).size != 3
+      if (options.keys & [:min, :max, :offset]).size != 3
         raise("Invalid mapping option: #{options.inspect}")
       end
       @uid_mapping = options
@@ -319,7 +319,7 @@ module Haconiwa
 
     def set_gid_mapping(options)
       unshare "user"
-      if (options.keys & [:min, :max, :options]).size != 3
+      if (options.keys & [:min, :max, :offset]).size != 3
         raise("Invalid mapping option: #{options.inspect}")
       end
       @gid_mapping = options

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -182,6 +182,19 @@ module Haconiwa
           f.close
         end
       end
+
+      pid = Process.pid
+      if m = namespace.uid_mapping
+        File.open("/proc/#{pid}/uid_map", "w") do |map|
+          map.write "#{m[:min].to_i} #{m[:offset].to_i} #{m[:max].to_i}"
+        end
+      end
+
+      if m = namespace.gid_mapping
+        File.open("/proc/#{pid}/gid_map", "w") do |map|
+          map.write "#{m[:min].to_i} #{m[:offset].to_i} #{m[:max].to_i}"
+        end
+      end
     end
 
     def apply_filesystem(base)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -200,12 +200,16 @@ module Haconiwa
     end
 
     def apply_namespace(namespace)
-      ::Namespace.unshare(namespace.to_flag_for_unshare)
+      if ::Namespace.unshare(namespace.to_flag_for_unshare) < 0
+        raise "Some namespace is unsupported by this kernel. Please check"
+      end
 
       if namespace.setns_on_run?
         namespace.ns_to_path.each do |ns, path|
           f = File.open(path)
-          ::Namespace.setns(ns, fd: f.fileno)
+          if ::Namespace.setns(ns, fd: f.fileno) < 0
+            raise "Some namespace is unsupported by this kernel. Please check"
+          end
           f.close
         end
       end

--- a/sample/uid_mapping.haco
+++ b/sample/uid_mapping.haco
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  config.name = "uid-mapping001"
+  config.init_command = "/bin/bash"
+
+  root = Pathname.new("/var/lib/haconiwa/uid-mapping001")
+  config.chroot_to root
+  config.bootstrap do |b|
+    b.strategy = "lxc"
+    b.os_type  = "debian"
+  end
+
+  config.mount_network_etc(root, host_root: "/etc")
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  config.namespace.set_uid_mapping min: 0, max: 10_000, offset: 100_000
+  config.namespace.set_gid_mapping min: 0, max: 10_000, offset: 100_000
+end


### PR DESCRIPTION
Add:

```ruby
  config.namespace.set_uid_mapping min: 0, max: 10_000, offset: 100_000
  config.namespace.set_gid_mapping min: 0, max: 10_000, offset: 100_000
```

Then new user namespace is spawned.

```
...
root      6404  0.2  0.4  17008  4384 pts/0    S    03:28   0:00  |                       \_ ./haconiwa run hoge2.haco
100000    6405  0.0  0.0   1524   936 pts/0    S+   03:28   0:00  |                           \_ /bin/sh
```

(NOTE: I ensured this works only on Ubuntu Xenial now...)