### PR TITLE
Bootstrap hooks

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -153,7 +153,11 @@ module Haconiwa
       @provision.provision!(self.rootfs)
     end
 
-    def start(*init_command)
+    def start(options, *init_command)
+      if options[:booting]
+        Logger.puts "Bootstrapping rootfs on run..."
+        create(options[:no_provision])
+      end
       self.container_pid_file ||= default_container_pid_file
       LinuxRunner.new(self).run(init_command)
     end

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -75,7 +75,9 @@ module Haconiwa
       self.strategy.bootstrap(self)
 
       if @postprocess
+        log("Start postprocess...")
         @postprocess.call(self)
+        log("Success!")
       end
 
       teardown

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -7,6 +7,10 @@ module Haconiwa
                   :git_url, :git_options, # for git clone
                   :archive_path, :tar_options # for unarchive
 
+    def initialize
+      @postprocess = nil
+    end
+
     def strategy=(name_or_instance)
       @strategy = if name_or_instance.is_a?(String) || name_or_instance.is_a?(Symbol)
                     case name_or_instance.to_s
@@ -43,6 +47,22 @@ module Haconiwa
       @code = the_code
     end
 
+    def postprocess(type, code=nil, &b)
+      case type.to_s
+      when "shell"
+        @postprocess = lambda { |_|
+          cmd = RunCmd.new("bootstrap.postprocess")
+          code.lines.each do |l|
+            cmd.run l.chomp
+          end
+        }
+      when "mruby"
+        @postprocess = b.nil? ?
+                         lambda { |boot| eval(code) } :
+                         b
+      end
+    end
+
     def boot!(r)
       self.root = r
       self.project_name ||= File.basename(root.to_str)
@@ -53,6 +73,10 @@ module Haconiwa
 
       # Requires duck typing bootstrap class
       self.strategy.bootstrap(self)
+
+      if @postprocess
+        @postprocess.call(self)
+      end
 
       teardown
     end

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -40,12 +40,19 @@ module Haconiwa
       opt = parse_opts(args, 'HACO_FILE [-- COMMAND...]') do |o|
         o.literal('D', 'daemon', "Force the container to be daemon")
         o.literal('T', 'no-daemon', "Force the container not to be daemon, stuck in tty")
+        o.literal('b', 'bootstrap', "Kick the bootstrap process on run")
+        o.literal('N', 'no-provision', "Skip provisioning, when you intend to kick bootstrap")
       end
+      cli_options = {}
 
       base, init = get_script_and_eval(opt.catchall.values)
       base.daemonize! if opt['D'].exist?
       base.cancel_daemonize! if opt['T'].exist?
-      base.run(*init)
+
+      cli_options[:booting] = opt['b'].exist?
+      cli_options[:no_provision] = opt['N'].exist?
+
+      base.run(cli_options, *init)
     end
 
     def self.attach(args)


### PR DESCRIPTION
Add a pstprocess hook. e.g.:

```ruby
  config.bootstrap do |b|
    b.strategy = "tarball"
    b.archive_path = "/usr/local/src/testball.tar.xz"
    b.tar_options = ["-v"]
    b.postprocess :shell, <<-SHELL
mknod -m 444 #{root}/dev/random c 1 9
mknod -m 444 #{root}/dev/urandom c 1 9
    SHELL
  end
```

And, I've added `haconiwa run --bootstrap` to boot on run