### PR TITLE
Dropping caps just before on exec

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -266,11 +266,11 @@ module Haconiwa
     end
 
     def whitelist_ids
-      @whitelist.map{|n| ::Capability.from_name(n) }
+      @whitelist.map{|n| get_cap_name(n) }
     end
 
     def blacklist_ids
-      @blacklist.map{|n| ::Capability.from_name(n) }
+      @blacklist.map{|n| get_cap_name(n) }
     end
 
     def drop(*keys)
@@ -279,6 +279,14 @@ module Haconiwa
 
     def acts_as_whitelist?
       ! @whitelist.empty?
+    end
+
+    private
+    def get_cap_name(n)
+      ::Capability.from_name(n)
+    rescue => e
+      STDERR.puts "Capability name looks invalid: #{n}"
+      raise e
     end
   end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -285,6 +285,7 @@ module Haconiwa
     }
     def apply_cgroup(base)
       base.cgroup.controllers.each do |controller|
+        Logger.debug "Creating cgroup controller #{controller}"
         Logger.err("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
 
         c = CG_MAPPING[controller].new(base.name)
@@ -315,10 +316,12 @@ module Haconiwa
         (0..38).each do |cap|
           break unless ::Capability.supported? cap
           next if ids.include?(cap)
+          Logger.debug "Dropping cap of #{cap}"
           ::Capability.drop_bound cap
         end
       else
         capabilities.blacklist_ids.each do |cap|
+          Logger.debug "Dropping cap of #{cap}"
           ::Capability.drop_bound cap
         end
       end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -33,7 +33,6 @@ module Haconiwa
           apply_filesystem(base)
           apply_rlimit(base.resource)
           apply_cgroup(base)
-          apply_capability(base.capabilities)
           apply_remount(base)
           ::Procutil.sethostname(base.name)
 
@@ -51,6 +50,7 @@ module Haconiwa
           do_chroot(base)
           switch_guid(base)
 
+          apply_capability(base.capabilities)
           Logger.info "Container is going to exec: #{base.init_command.inspect}"
           Exec.exec(*base.init_command)
         end
@@ -118,8 +118,8 @@ module Haconiwa
         ::Namespace.setns(base.namespace.to_flag_without_pid, pid: base.pid)
 
         apply_cgroup(base)
-        apply_capability(base.attached_capabilities)
         do_chroot(base)
+        apply_capability(base.attached_capabilities)
         Logger.info "Attach process is going to exec: #{base.init_command.inspect}"
         Exec.exec(*exe)
       end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -325,6 +325,9 @@ module Haconiwa
           ::Capability.drop_bound cap
         end
       end
+    rescue => e
+      showid = capabilities.acts_as_whitelist? ? capabilities.whitelist_ids : capabilities.blacklist_ids
+      Logger.err "Maybe there are unsupported caps in #{showid.inspect}: #{e.class} - #{e.message}"
     end
 
     def apply_rlimit(rlimit)

--- a/sample/sleeper001.haco
+++ b/sample/sleeper001.haco
@@ -17,8 +17,8 @@ Haconiwa.define do |config|
   # The bootstrap process...
   # Choose lxc or debootstrap:
   config.bootstrap do |b|
-    b.strategy = "lxc"
-    b.os_type  = "alpine"
+    b.strategy = "git"
+    b.git_url = "https://github.com/haconiwa/haconiwa-image-php-tester"
 
     # b.strategy = "debootstrap"
     # b.variant = "minbase"


### PR DESCRIPTION
* Invoke `apply_capability` just before exec'ing (after unshare and switch g/uids)
  * According to [man 7 user_namespace](http://man7.org/linux/man-pages/man7/user_namespaces.7.html), splitting user namespace also splits user capabilities. So it is more desirable to set caps just after g/uid switching
* Fixed error messages