### PR TITLE
[WIP]Set uid/gid properly on attach

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -17,6 +17,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
   spec.add_dependency 'mruby-time'      , :core => 'mruby-time'
 
+  spec.add_dependency 'mruby-forwardable', :mgem => 'mruby-forwardable'
   spec.add_dependency 'mruby-capability', :mgem => 'mruby-capability'
   spec.add_dependency 'mruby-cgroup'    , :mgem => 'mruby-cgroup'
   spec.add_dependency 'mruby-dir'       , :mgem => 'mruby-dir' # with Dir#chroot
@@ -25,7 +26,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-io'        , :mgem => 'mruby-io'
   spec.add_dependency 'mruby-linux-namespace', :mgem => 'mruby-linux-namespace'
   spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
-  spec.add_dependency 'mruby-regexp-pcre', :mgem => 'mruby-regexp-pcre'
+  #spec.add_dependency 'mruby-regexp-pcre', :mgem => 'mruby-regexp-pcre'
   spec.add_dependency 'mruby-signal'    , :mgem => 'mruby-signal'
   spec.add_dependency 'mruby-socket'    , :mgem => 'mruby-socket'
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -375,18 +375,18 @@ module Haconiwa
     end
 
     def uid=(newid)
-      if newid.is_a?(String)
+      if newid.is_a?(String) and newid !~ /^\d+$/
         @uid = ::Process::UID.from_name newid
       else
-        @uid = newid
+        @uid = newid.to_i
       end
     end
 
     def gid=(newid)
-      if newid.is_a?(String)
+      if newid.is_a?(String) and newid !~ /^\d+$/
         @gid = ::Process::GID.from_name newid
       else
-        @gid = newid
+        @gid = newid.to_i
       end
     end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1,5 +1,7 @@
 module Haconiwa
   class Base
+    extend ::Forwardable
+
     attr_accessor :name,
                   :container_pid_file,
                   :filesystem,
@@ -7,6 +9,7 @@ module Haconiwa
                   :cgroup,
                   :namespace,
                   :capabilities,
+                  :guid,
                   :attached_capabilities,
                   :signal_handler,
                   :pid,
@@ -16,10 +19,14 @@ module Haconiwa
                   :network_mountpoint,
                   :cleaned
 
-    attr_reader   :init_command,
-                  :uid,
+    attr_reader   :init_command
+
+    delegate     [:uid,
+                  :uid=,
                   :gid,
-                  :groups
+                  :gid=,
+                  :groups,
+                  :groups=] => :@guid
 
     def self.define(&b)
       base = new
@@ -35,6 +42,7 @@ module Haconiwa
       @cgroup = CGroup.new
       @namespace = Namespace.new
       @capabilities = Capabilities.new
+      @guid = Guid.new
       @signal_handler = SignalHandler.new(self)
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
@@ -42,8 +50,6 @@ module Haconiwa
       @container_pid_file = nil
       @pid = nil
       @daemon = false
-      @uid = @gid = nil
-      @groups = []
       @network_mountpoint = []
       @cleaned = false
     end
@@ -89,34 +95,6 @@ module Haconiwa
       from = options[:host_root] || '/etc'
       self.network_mountpoint << MountPoint.new("#{from}/resolv.conf", to: "#{root}/etc/resolv.conf")
       self.network_mountpoint << MountPoint.new("#{from}/hosts",       to: "#{root}/etc/hosts")
-    end
-
-    def uid=(newid)
-      if newid.is_a?(String)
-        @uid = ::Process::UID.from_name newid
-      else
-        @uid = newid
-      end
-    end
-
-    def gid=(newid)
-      if newid.is_a?(String)
-        @gid = ::Process::GID.from_name newid
-      else
-        @gid = newid
-      end
-    end
-
-    def groups=(newgroups)
-      @groups.clear
-      newgroups.each do |newid|
-        if newid.is_a?(String)
-          @groups << ::Process::GID.from_name(newid)
-        else
-          @groups << newid
-        end
-      end
-      @groups
     end
 
     def add_handler(sig, &b)
@@ -383,6 +361,45 @@ module Haconiwa
 
     def to_flag_without_pid_and_user
       to_flag & (~(::Namespace::CLONE_NEWPID | ::Namespace::CLONE_NEWUSER))
+    end
+  end
+
+  class Guid
+    attr_reader :uid,
+                :gid,
+                :groups
+
+    def initialize
+      @uid = @gid = nil
+      @groups = []
+    end
+
+    def uid=(newid)
+      if newid.is_a?(String)
+        @uid = ::Process::UID.from_name newid
+      else
+        @uid = newid
+      end
+    end
+
+    def gid=(newid)
+      if newid.is_a?(String)
+        @gid = ::Process::GID.from_name newid
+      else
+        @gid = newid
+      end
+    end
+
+    def groups=(newgroups)
+      @groups.clear
+      newgroups.each do |newid|
+        if newid.is_a?(String)
+          @groups << ::Process::GID.from_name(newid)
+        else
+          @groups << newid
+        end
+      end
+      @groups
     end
   end
 

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -61,6 +61,8 @@ module Haconiwa
         o.string('n', 'name', 'CONTAINER_NAME', "Container's name. Set if the name is dynamically defined")
         o.string('A', 'allow', 'CAPS[,CAPS...]', "Capabilities to allow attached process. Independent container's own caps")
         o.string('D', 'drop', 'CAPS[,CAPS...]', "Capabilities to drop from attached process. Independent container's own caps")
+        o.string('u', 'uid', 'UID_OR_NAME', "The UID to be set to attaching process")
+        o.string('g', 'gid', 'GID_OR_NAME', "The GID to be set to attaching process")
       end
 
       base, exe = get_script_and_eval(opt.catchall.values)
@@ -71,6 +73,13 @@ module Haconiwa
       if opt['A'].exist? or opt['D'].exist?
         base.attached_capabilities.allow(*opt['A'].value.split(',')) if opt['A'].exist?
         base.attached_capabilities.drop(*opt['D'].value.split(','))  if opt['D'].exist?
+      end
+
+      if opt['u'].exist?
+        base.uid = opt['u'].value
+      end
+      if opt['g'].exist?
+        base.gid = opt['g'].value
       end
 
       base.attach(*exe)


### PR DESCRIPTION
* Small refacrtor: split uid/gid config model
* `attach` supports `-u/--uid` and `-g/--gid`. If these are specified, DSL's uid/gid will be ignored.