### PR TITLE
Revert "Replace fork & unshare to clone(2)"

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -341,10 +341,6 @@ module Haconiwa
       !@ns_to_path.empty?
     end
 
-    # def enter_existing_pid?
-    #   !! @ns_to_path["pid"]
-    # end
-
     def to_bit(ns)
       case ns
       when String, Symbol
@@ -362,14 +358,6 @@ module Haconiwa
 
     def to_flag_for_unshare
       f = to_flag_without_pid_and_user
-      @ns_to_path.keys.each do |mask|
-        f &= (~mask)
-      end
-      f
-    end
-
-    def to_flag_for_clone
-      f = to_flag & (~::Namespace::CLONE_NEWUSER)
       @ns_to_path.keys.each do |mask|
         f &= (~mask)
       end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -20,26 +20,25 @@ module Haconiwa
       end
 
       wrap_daemonize do |base, notifier|
+        jail_pid(base)
         # The pipe to set guid maps
         if base.namespace.use_guid_mapping?
           r,  w  = IO.pipe
           r2, w2 = IO.pipe
         end
 
-        runner = self
-        pid = ::Namespace.clone(base.namespace.to_flag_for_clone) do
+        pid = Process.fork do
           [r, w2].each {|io| io.close if io }
           ::Procutil.setsid
 
-          # doing some setns(2)
-          runner.apply_namespace(base.namespace)
-          runner.apply_filesystem(base)
-          runner.apply_rlimit(base.resource)
-          runner.apply_cgroup(base)
-          runner.apply_remount(base)
+          apply_namespace(base.namespace)
+          apply_filesystem(base)
+          apply_rlimit(base.resource)
+          apply_cgroup(base)
+          apply_remount(base)
           ::Procutil.sethostname(base.name)
 
-          runner.apply_user_namespace(base.namespace)
+          apply_user_namespace(base.namespace)
           if base.namespace.use_guid_mapping?
             # ping and pong between parent
             w.puts "unshared"
@@ -47,14 +46,14 @@ module Haconiwa
 
             r2.read
             r2.close
-            runner.switch_current_namespace_root
+            switch_current_namespace_root
           end
 
-          runner.do_chroot(base)
+          do_chroot(base)
           ::Procutil.daemon_fd_reopen if base.daemon?
 
-          runner.apply_capability(base.capabilities)
-          runner.switch_guid(base.guid)
+          apply_capability(base.capabilities)
+          switch_guid(base.guid)
 
           Logger.info "Container is going to exec: #{base.init_command.inspect}"
           ::Procutil.mark_cloexec
@@ -185,6 +184,8 @@ module Haconiwa
       base.cleaned = true
     end
 
+    private
+
     def wrap_daemonize(&b)
       if @base.daemon?
         Logger.info "Container is running in daemon mode"
@@ -212,7 +213,17 @@ module Haconiwa
       end
     end
 
+    def jail_pid(base)
+      if base.namespace.use_pid_ns
+        ::Namespace.unshare(::Namespace::CLONE_NEWPID)
+      end
+    end
+
     def apply_namespace(namespace)
+      if ::Namespace.unshare(namespace.to_flag_for_unshare) < 0
+        Logger.err "Some namespace is unsupported by this kernel. Please check"
+      end
+
       if namespace.setns_on_run?
         namespace.ns_to_path.each do |ns, path|
           next if ns == ::Namespace::CLONE_NEWUSER


### PR DESCRIPTION
Reverts haconiwa/haconiwa#56

Direct use of `clone(2)` seems more dangerous than I had expected, so keep this patch to `use-clone` branch and revert it in master.