### PR TITLE
Persistent namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ And `attach` is not concerned with capabilities which is granted to container. S
 
 * `config.resource.set_limit` - Set the resource limit of container, using `setrlimit`
 * `config.cgroup` - Assign cgroup parameters via `[]=`
-* `config.namespace.unshare` - Unshare the namespaces like `"mount"`, `"ipc"` or `"pid"`
+* `config.namespace.unshare` - Unshare the namespaces like `"mount"`, `"ipc"` or `"pid" ...`. `persist_in` option make the specified namespace persist in a bind-moounted-file
+  * See: http://karelzak.blogspot.jp/2015/04/persistent-namespaces.html
 * `config.capabilities.allow` - Allow capabilities on container root. Setting parameters other than `:all` should make this acts as whitelist
 * `config.capabilities.drop` - Drop capabilities of container root. Default to act as blacklist
 * `config.add_mount_point` - Add the mount point odf container

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -289,6 +289,7 @@ module Haconiwa
       @uid_mapping = nil
       @gid_mapping = nil
     end
+    attr_reader :namespaces
 
     def unshare(ns, options={})
       flag = to_bit(ns)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -284,18 +284,22 @@ module Haconiwa
     }
 
     def initialize
-      @use_ns = []
+      @namespaces = {}
       @ns_to_path = {}
       @uid_mapping = nil
       @gid_mapping = nil
     end
 
-    def unshare(ns)
+    def unshare(ns, options={})
       flag = to_bit(ns)
       if flag == ::Namespace::CLONE_NEWPID
         @use_pid_ns = true
       end
-      @use_ns << flag
+      @namespaces[flag] = options
+    end
+
+    def active_namespaces
+      @namespaces.keys
     end
 
     def enter(ns, path_or_opt)
@@ -351,7 +355,7 @@ module Haconiwa
     end
 
     def to_flag
-      @use_ns.inject(0x00000000) { |dst, flag|
+      active_namespaces.inject(0x00000000) { |dst, flag|
         dst |= flag
       }
     end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -336,6 +336,10 @@ module Haconiwa
       !!@uid_mapping or !!@gid_mapping
     end
 
+    def enter_existing_pidns?
+      @ns_to_path.has_key? ::Namespace::CLONE_NEWPID
+    end
+
     attr_reader :use_pid_ns, :ns_to_path, :uid_mapping, :gid_mapping
 
     def use_netns(name)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -29,6 +29,7 @@ module Haconiwa
         done, kick_ok = IO.pipe
 
         pid = Process.fork do
+          ::Procutil.mark_cloexec
           [r, w2].each {|io| io.close if io }
           done.close
           ::Procutil.setsid
@@ -60,7 +61,6 @@ module Haconiwa
           kick_ok.close
 
           Logger.info "Container is going to exec: #{base.init_command.inspect}"
-          ::Procutil.mark_cloexec
           Exec.exec(*base.init_command)
         end
         kick_ok.close

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -227,8 +227,11 @@ module Haconiwa
               ::Namespace.unshare(::Namespace::CLONE_NEWPID)
             elsif base.namespace.enter_existing_pidns?
               f = File.open(namespace.ns_to_path[::Namespace::CLONE_NEWPID])
-              ::Namespace.setns(ns, fd: f.fileno)
+              r = ::Namespace.setns(ns, fd: f.fileno)
               f.close
+              r
+            else
+              0
             end
       if ret < 0
         Logger.err "Unsharing or setting PID namespace failed"


### PR DESCRIPTION
See: http://karelzak.blogspot.jp/2015/04/persistent-namespaces.html

```
mount --bind /root/mntns /root/mntns
mount --make-rprivate /root/mntns
```

Then

```ruby
config.namespace.unshare "mount", persist_in: "/root/mntns/mount.test"
```

After all, mount namespae is persisted and can be reentered.