### PR TITLE
Add timer hook(config.after_spawn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
   * We can declare `run_shell` multiple times
   * Set name by `name:` option, then you can specify provision operation by `haconiwa provision --run-only=...`
 
-#### Running environment
+#### Running container environment
 
 * `config.resource.set_limit` - Set the resource limit of container, using `setrlimit`
 * `config.cgroup` - Assign cgroup parameters via `[]=`
@@ -155,10 +155,14 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.mount_independent` - Mount the independent filesystems: `"procfs", "sysfs", "devtmpfs", "devpts" and "shm"` in the newborn container. Useful if `"pid"` or `"net"` are unshared
 * `config.chroot_to` - The new chroot root
 * `config.uid=/config.gid=` - The new container's running uid/gid. `groups=` is also respected
-* `config.add_handler` - Define signal handler at supervisor process(not container itself). Available signals are `SIGTTIN/SIGTTOU/SIGUSR1/SIGUSR2`. See [handler example](./sample/cpu.haco).
 
 You can pick your own parameters for your use case of container.
 e.g. just using `mount` namespace unshared, container with common filesystem, limit the cgroups for big resource job and so on.
+
+#### Hooks
+
+* `config.after_spawn(option, &block)` - Define timer handler. Pass option like `msec: 10 * 60 * 1000`, then after 10 min passed, the defined hook will be invoked
+* `config.add_signal_handler(signame, &block)` - Define signal handler at supervisor process(not container itself). Available signals are `SIGTTIN/SIGTTOU/SIGUSR1/SIGUSR2`. See [handler example](./sample/cpu.haco).
 
 Please look into [`sample`](./sample) directory.
 

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -26,7 +26,8 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-etcd'      , :mgem => 'mruby-etcd'
   spec.add_dependency 'mruby-io'        , :mgem => 'mruby-io'
   spec.add_dependency 'mruby-linux-namespace', :mgem => 'mruby-linux-namespace'
-  spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
+  # spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
+  spec.add_dependency 'mruby-process'   , :github => 'udzura/mruby-process', :branch => 'add-some-consts'
   #spec.add_dependency 'mruby-regexp-pcre', :mgem => 'mruby-regexp-pcre'
   spec.add_dependency 'mruby-socket'    , :mgem => 'mruby-socket'
 

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -28,7 +28,6 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-linux-namespace', :mgem => 'mruby-linux-namespace'
   spec.add_dependency 'mruby-process'   , :mgem => 'mruby-process'
   #spec.add_dependency 'mruby-regexp-pcre', :mgem => 'mruby-regexp-pcre'
-  spec.add_dependency 'mruby-signal'    , :mgem => 'mruby-signal'
   spec.add_dependency 'mruby-socket'    , :mgem => 'mruby-socket'
 
   spec.add_dependency 'mruby-argtable'  , :github => 'udzura/mruby-argtable', :branch => 'static-link-argtable3'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -100,9 +100,10 @@ module Haconiwa
       self.network_mountpoint << MountPoint.new("#{from}/hosts",       to: "#{root}/etc/hosts")
     end
 
-    def add_handler(sig, &b)
+    def add_signal_handler(sig, &b)
       @signal_handler.add_handler(sig, &b)
     end
+    alias add_handler add_signal_handler
 
     def after_spawn(options={}, &hook)
       self.waitloop.hooks << WaitLoop::TimerHook.new(options, &hook)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -19,7 +19,8 @@ module Haconiwa
                   :network_mountpoint,
                   :cleaned
 
-    attr_reader   :init_command
+    attr_reader   :init_command,
+                  :waitloop
 
     delegate     [:uid,
                   :uid=,
@@ -52,6 +53,8 @@ module Haconiwa
       @daemon = false
       @network_mountpoint = []
       @cleaned = false
+
+      @waitloop = WaitLoop.new
     end
 
     def init_command=(cmd)
@@ -99,6 +102,10 @@ module Haconiwa
 
     def add_handler(sig, &b)
       @signal_handler.add_handler(sig, &b)
+    end
+
+    def after_spawn(options={}, &hook)
+      self.waitloop.hooks << WaitLoop::TimerHook.new(options, &hook)
     end
 
     def bootstrap

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -44,7 +44,7 @@ module Haconiwa
       @namespace = Namespace.new
       @capabilities = Capabilities.new
       @guid = Guid.new
-      @signal_handler = SignalHandler.new(self)
+      @signal_handler = SignalHandler.new
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
       @init_command = ["/bin/bash"] # FIXME: maybe /sbin/init is better

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -63,6 +63,7 @@ module Haconiwa
           Logger.info "Container is going to exec: #{base.init_command.inspect}"
           Exec.exec(*base.init_command)
         end
+        base.pid = pid
         kick_ok.close
 
         File.open(base.container_pid_file, 'w') {|f| f.write pid }

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -78,8 +78,6 @@ module Haconiwa
           w2.close
         end
 
-        base.signal_handler.register_handlers!
-
         done.read # wait for container is done
         done.close
         persist_namespace(pid, base.namespace)
@@ -92,6 +90,8 @@ module Haconiwa
         Logger.puts "Container fork success and going to wait: pid=#{pid}"
         base.waitloop.register_hooks(base)
         base.waitloop.register_sighandlers(base, self, @etcd)
+        base.waitloop.register_custom_sighandlers(base, base.signal_handler)
+
         pid, status = base.waitloop.run_and_wait(pid)
         cleanup_supervisor(base, @etcd)
         if status.success?

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -101,7 +101,8 @@ module Haconiwa
         end
 
         Logger.puts "Container fork success and going to wait: pid=#{pid}"
-        pid, status = Process.waitpid2 pid
+        base.waitloop.register_hooks(base)
+        pid, status = base.waitloop.run_and_wait(pid)
         cleanup_supervisor(base, @etcd)
         if status.success?
           Logger.puts "Container successfully exited: #{status.inspect}"

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -89,19 +89,9 @@ module Haconiwa
           notifier.close # notify container is up
         end
 
-        runner, etcd = self, @etcd
-        [:SIGTERM, :SIGINT, :SIGHUP, :SIGPIPE].each do |sig|
-          Signal.trap(sig) do |signo|
-            unless base.cleaned
-              Logger.warning "Supervisor received unintended kill. Cleanup..."
-              runner.cleanup_supervisor(base, etcd)
-            end
-            exit 127
-          end
-        end
-
         Logger.puts "Container fork success and going to wait: pid=#{pid}"
         base.waitloop.register_hooks(base)
+        base.waitloop.register_sighandlers(base, self, @etcd)
         pid, status = base.waitloop.run_and_wait(pid)
         cleanup_supervisor(base, @etcd)
         if status.success?

--- a/mrblib/haconiwa/signal_handler.rb
+++ b/mrblib/haconiwa/signal_handler.rb
@@ -1,9 +1,9 @@
 module Haconiwa
   class SignalHandler
-    def initialize(base)
-      @base = base
+    def initialize
       @handlers = {}
     end
+    attr_reader :handlers
 
     def registered_signals
       @handlers.keys
@@ -14,15 +14,6 @@ module Haconiwa
         @handlers[sig.to_sym] = b
       else
         raise TypeError, "Unsupported signal: #{sig.inspect}"
-      end
-    end
-
-    def register_handlers!
-      base = @base
-      @handlers.each do |sig, handler|
-        ::Signal.trap(sig) do |signo|
-          handler.call(base, signo)
-        end
       end
     end
   end

--- a/mrblib/haconiwa/signal_handler.rb
+++ b/mrblib/haconiwa/signal_handler.rb
@@ -9,6 +9,10 @@ module Haconiwa
       @handlers.keys
     end
 
+    def each(&b)
+      @handlers.each(&b)
+    end
+
     def add_handler(sig, &b)
       if [:USR1, :USR2, :TTIN, :TTOU].include? sig.to_sym
         @handlers[sig.to_sym] = b

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -1,0 +1,29 @@
+module Haconiwa
+  class WaitLoop
+    def initialize
+      @hooks = []
+    end
+    attr_reader :hooks
+
+    def run
+    end
+
+    class TimerHook
+      def initialize(timing={}, &b)
+        @timing = if s = timing[:msec]
+                    s
+                  elsif s = timing[:sec]
+                    s * 1000
+                  elsif s = timing[:min]
+                    s * 1000 * 60
+                  elsif s = timing[:hour]
+                    s * 1000 * 60 * 60
+                  else
+                    raise(ArgumentError, "Invalid option: #{timing.inspect}")
+                  end
+        @proc = b
+      end
+      attr_reader :timing, :proc
+    end
+  end
+end

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -77,9 +77,13 @@ module Haconiwa
 
       def register(t, base)
         t.start(@timing, 0) do
-          Logger.debug "The timer hook(#{@id}) invoked after #{@timing} msec"
-          @proc.call(base)
-          Logger.debug "The timer hook(#{@id}) success"
+          begin
+            Logger.debug "The timer hook(#{@id}) invoked after #{@timing} msec"
+            @proc.call(base)
+            Logger.debug "The timer hook(#{@id}) success"
+          rescue => e
+            Logger.debug "Something is wrong on timer hook(#{@id}): #{e.class}/#{e.message}"
+          end
         end
       end
     end

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -16,7 +16,7 @@ module Haconiwa
     end
 
     def register_sighandlers(base, runner, etcd)
-      sigs = []
+      done = []
       [:SIGTERM, :SIGINT, :SIGHUP, :SIGPIPE].each do |sig|
         s = UV::Signal.new()
         s.start(UV::Signal.const_get(sig)) do |signo|
@@ -28,6 +28,19 @@ module Haconiwa
           exit 127
         end
       end
+      done
+    end
+
+    def register_custom_sighandlers(base, handlers)
+      done = []
+      handlers.each do |sig, callback|
+        s = UV::Signal.new()
+        s.start(UV::Signal.const_get(sig)) do |signo|
+          callback.call(base)
+        end
+        done << s
+      end
+      done
     end
 
     def run_and_wait(pid)

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -71,7 +71,7 @@ module Haconiwa
                     raise(ArgumentError, "Invalid option: #{timing.inspect}")
                   end
         @proc = b
-        @id = SecureRandom.secure_uuid
+        @id = UUID.secure_uuid
       end
       attr_reader :timing, :proc, :id
 

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -5,7 +5,31 @@ module Haconiwa
     end
     attr_reader :hooks
 
-    def run
+    def register_hooks(base)
+      timers = []
+      @hooks.each do |hook|
+        t = UV::Timer.new
+        hook.register(t, base)
+        timers << t
+      end
+      timers
+    end
+
+    def register_sighandlers(base)
+    end
+
+    def run_and_wait(pid)
+      main = UV::Timer.new
+      p = s = nil
+      main.start(100, 100) do
+        p, s = Process.waitpid2(pid, Process::WNOHANG)
+        if p
+          Logger.puts "Container(#{p}) finish detected: #{s.inspect}"
+          UV::default_loop.stop()
+        end
+      end
+      UV::run()
+      return [p, s]
     end
 
     class TimerHook
@@ -22,8 +46,17 @@ module Haconiwa
                     raise(ArgumentError, "Invalid option: #{timing.inspect}")
                   end
         @proc = b
+        @id = SecureRandom.secure_uuid
       end
-      attr_reader :timing, :proc
+      attr_reader :timing, :proc, :id
+
+      def register(t, base)
+        t.start(@timing, 0) do
+          Logger.debug "The timer hook(#{@id}) invoked after #{@timing} msec"
+          @proc.call(base)
+          Logger.debug "The timer hook(#{@id}) success"
+        end
+      end
     end
   end
 end

--- a/sample/timer.haco
+++ b/sample/timer.haco
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  config.name = "haconiwa-auto-droptest"
+  # Ruby loop daemon:
+  config.init_command = ["/usr/bin/ruby", "-e", "loop { sleep 1 }"]
+  config.daemonize!
+
+  root = Pathname.new("/var/lib/haconiwa/#{config.name}")
+  config.chroot_to root
+
+  config.bootstrap do |b|
+    b.strategy = "git"
+    b.git_url = "https://github.com/haconiwa/haconiwa-image-alpine"
+  end
+
+  config.provision do |p|
+    p.run_shell <<-SHELL
+apk add --update bash
+apk add --update ruby
+    SHELL
+  end
+
+  config.after_spawn(msec: 30 * 1000) do |base|
+    Haconiwa::Logger.info("Process killed: #{base.pid}")
+    ::Process.kill :TERM, base.pid
+  end
+
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+end


### PR DESCRIPTION
e.g. terminate container by elapsed time:

```ruby
config.after_spawn(msec: 10 * 60 * 1000) do |base|
  ::Process.kill :TERM, base.pid
end
```

Also, signal handlers are moved to `UV::Signal` based ones.