### PR TITLE
Introduce default capabilities by whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.cgroup` - Assign cgroup parameters via `[]=`
 * `config.namespace.unshare` - Unshare the namespaces like `"mount"`, `"ipc"` or `"pid" ...`. `persist_in` option make the specified namespace persist in a bind-moounted-file
   * See: http://karelzak.blogspot.jp/2015/04/persistent-namespaces.html
+* `config.capabilities.reset_to_privileged!` - Haconiwa has default capability whitelist to use. If you want to use customized black/whitelist, declare this first
 * `config.capabilities.allow` - Allow capabilities on container root. Setting parameters other than `:all` should make this acts as whitelist
 * `config.capabilities.drop` - Drop capabilities of container root. Default to act as blacklist
 * `config.add_mount_point` - Add the mount point odf container

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -235,9 +235,27 @@ module Haconiwa
   end
 
   class Capabilities
+    DEFAULT_SAFE_CAPABILITIES = %w(
+      cap_audit_read
+      cap_chown
+      cap_dac_override
+      cap_fowner
+      cap_fsetid
+      cap_net_raw
+      cap_setgid
+      cap_setfcap
+      cap_setpcap
+      cap_setuid
+    )
+
     def initialize
       @blacklist = []
-      @whitelist = []
+      @whitelist = DEFAULT_SAFE_CAPABILITIES.dup
+    end
+
+    def reset_to_privileged!
+      @blacklist.clear
+      @whitelist.clear
     end
 
     def allow(*keys)

--- a/mrblib/haconiwa/generator.rb
+++ b/mrblib/haconiwa/generator.rb
@@ -67,8 +67,13 @@ apk add --update bash
   # config.cgroup["cpu.cfs_period_us"] = 100000
   # config.cgroup["cpu.cfs_quota_us"]  =  30000
 
-  # The linux capability blacklist
-  # These are useful when you run container as root:
+  # The linux kernel capability:
+  # Haconiwa has default capability whitelist and applies it when there's no config
+  # If you want to use customized blacklist, first uncomment below:
+  # config.capabilities.reset_to_privileged!
+
+  # Then declare:
+  # config.capabilities.allow :all
   # config.capabilities.drop "cap_sys_time"
   # config.capabilities.drop "cap_kill"
 

--- a/sample/drop_cap_sys_time.haco
+++ b/sample/drop_cap_sys_time.haco
@@ -16,6 +16,8 @@ haconiwa = Haconiwa::Base.define do |config|
   config.namespace.unshare "uts"
   config.namespace.unshare "pid"
 
+  # Allow all but cap_sys_time
+  config.capabilities.reset_to_privileged!
   config.capabilities.allow :all
   config.capabilities.drop "cap_sys_time"
 


### PR DESCRIPTION
If you set no capability config, new process has these caps:

```console
bash-4.3# getpcaps $$
Capabilities for `1': = cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_setgid,cap_setuid,cap_setpcap,cap_net_raw,cap_setfcap+ep
```

Explicit `reset_to_privileged!` declaration reset caps to blank, then we can customize caps as we want.