### PR TITLE
Refine cwd handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 #### Running container environment
 
 * `config.environ` - A hash to pass environment variables to a created container. e.g. `config.environ = {"FOO_KEY" => "value", ...}`
+* `config.workdir` - The working directory of haconiwa's init command
 * `config.resource.set_limit` - Set the resource limit of container, using `setrlimit`
 * `config.cgroup` - Assign cgroup parameters via `[]=`
 * `config.namespace.unshare` - Unshare the namespaces like `"mount"`, `"ipc"` or `"pid" ...`. `persist_in` option make the specified namespace persist in a bind-moounted-file
@@ -153,7 +154,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.capabilities.reset_to_privileged!` - Haconiwa has default capability whitelist to use. If you want to use customized black/whitelist, declare this first
 * `config.capabilities.allow` - Allow capabilities on container root. Setting parameters other than `:all` should make this acts as whitelist
 * `config.capabilities.drop` - Drop capabilities of container root. Default to act as blacklist
-* `config.add_mount_point` - Add the mount point odf container
+* `config.add_mount_point` - Add the mount point of container. Source directory is resolved from the directory where a user run haconiwa
 * `config.mount_independent` - Mount the independent filesystems: `"procfs", "sysfs", "devtmpfs", "devpts" and "shm"` in the newborn container. Useful if `"pid"` or `"net"` are unshared
 * `config.chroot_to` - The new chroot root
 * `config.uid=/config.gid=` - The new container's running uid/gid. `groups=` is also respected

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -499,7 +499,8 @@ module Haconiwa
   class MountPoint
     def initialize(point, options={})
       @src = point.to_s
-      @dest = options.delete(:to).to_s
+      @dest = options.delete(:to)
+      @dest = @dest.to_s if @dest
       @fs = options.delete(:fs)
       @options = options
     end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -4,6 +4,7 @@ module Haconiwa
 
     attr_accessor :name,
                   :container_pid_file,
+                  :workdir,
                   :filesystem,
                   :resource,
                   :cgroup,
@@ -39,6 +40,7 @@ module Haconiwa
     end
 
     def initialize
+      @workdir = "/"
       @filesystem = Filesystem.new
       @resource = Resource.new
       @cgroup = CGroup.new

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -498,12 +498,21 @@ module Haconiwa
 
   class MountPoint
     def initialize(point, options={})
-      @src = point
-      @dest = options.delete(:to)
+      @src = point.to_s
+      @dest = options.delete(:to).to_s
       @fs = options.delete(:fs)
       @options = options
     end
     attr_accessor :src, :dest, :fs, :options
+
+    def normalized_src(cwd="/")
+      if @src.start_with?('/')
+        @src
+      else
+        fullpath = File.expand_path [cwd, @src].join("/")
+        File.exist?(fullpath) ? fullpath : @src
+      end
+    end
   end
 
   def self.define(&b)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -370,8 +370,8 @@ module Haconiwa
     end
 
     def do_chroot(base)
+      Dir.chdir File.expand_path([base.filesystem.chroot, base.workdir].join('/'))
       Dir.chroot base.filesystem.chroot
-      Dir.chdir "/"
     end
 
     def switch_current_namespace_root

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -278,22 +278,23 @@ module Haconiwa
     end
 
     def apply_filesystem(base)
+      cwd = Dir.pwd
       m = Mount.new
       m.make_private "/"
       owner_options = base.rootfs.to_owner_options
       base.filesystem.mount_points.each do |mp|
         case
         when mp.fs
-          m.mount mp.src, mp.dest, owner_options.merge(mp.options).merge(type: mp.fs)
+          m.mount mp.normalized_src(cwd), mp.dest, owner_options.merge(mp.options).merge(type: mp.fs)
         else
-          m.bind_mount mp.src, mp.dest, owner_options.merge(mp.options)
+          m.bind_mount mp.normalized_src(cwd), mp.dest, owner_options.merge(mp.options)
         end
       end
       base.network_mountpoint.each do |mp|
         unless File.exist? mp.dest
           File.open(mp.dest, "w+") {|f| f.print "" }
         end
-        m.bind_mount mp.src, mp.dest, {readonly: true}.merge(owner_options)
+        m.bind_mount mp.normalized_src(cwd), mp.dest, {readonly: true}.merge(owner_options)
       end
     end
 

--- a/sample/chroot.haco
+++ b/sample/chroot.haco
@@ -24,10 +24,11 @@ Haconiwa.define do |config|
   config.mount_independent("devpts")
   config.mount_independent("shm")
   config.chroot_to root
+  config.workdir = "/home/haconiwa"
 
   config.namespace.unshare "mount"
   config.namespace.unshare "ipc"
   config.namespace.unshare "uts"
   config.namespace.unshare "pid"
-  config.namespace.enter   "net", via: "/var/run/netns/haco001"
+  #config.namespace.enter   "net", via: "/var/run/netns/haco001"
 end


### PR DESCRIPTION
Supported:

* init's working dir: `config.workdir`
* resolves mount target src dir from cwd