### PR TITLE
[WIP]First implementation of multi-container ready haconiwa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
 branches:
   only:
     - master
+    - multicontainer
 cache:
   directories:
     - mruby

--- a/bintest/walkthrough.rb
+++ b/bintest/walkthrough.rb
@@ -25,6 +25,7 @@ def run_haconiwa(subcommand, *args)
   if s.coredump?
     raise "[BUG] haconiwa got SEGV. Abort testing"
   end
+  puts(o) if ENV['DEBUGGING']
   return [o, s]
 end
 
@@ -72,23 +73,12 @@ assert('walkthrough') do
     subprocess = `pstree -Al $(pgrep haconiwa) | awk -F'---' '{print $2}'`
     assert_false subprocess.empty?
 
-    output, status = run_haconiwa "ps"
-    assert_include output, "NAME"
-    assert_include output, test_name
-    assert_include output, HACONIWA_TMP_ROOT
-
     output, status = run_haconiwa "kill", haconame
     assert_true status.success?, "Process did not exit cleanly: kill"
 
     processes = `ps axf`
     assert_not_include processes, "haconiwa run #{haconame}"
   end
-end
-
-assert('empty ps') do
-  output, status = run_haconiwa "ps"
-  assert_true status.success?, "Process did not exit cleanly: ps"
-  assert_equal 1, output.chomp.lines.to_a.size
 end
 
 ### end sudo test

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -229,9 +229,9 @@ module Haconiwa
       end
     end
 
-    def kill(signame)
+    def kill(signame, timeout)
       containers_real_run.each do |c|
-        c.kill(signame)
+        c.kill(signame, timeout)
       end
     end
   end
@@ -341,9 +341,9 @@ module Haconiwa
       LinuxRunner.new(self).attach(run_command)
     end
 
-    def kill(signame)
+    def kill(signame, timeout)
       self.container_pid_file ||= default_container_pid_file
-      LinuxRunner.new(self).kill(signame)
+      LinuxRunner.new(self).kill(signame, timeout)
     end
   end
 

--- a/mrblib/haconiwa/bootstrap.rb
+++ b/mrblib/haconiwa/bootstrap.rb
@@ -1,7 +1,7 @@
 module Haconiwa
   class Bootstrap
     attr_reader :strategy
-    attr_accessor :root,
+    attr_accessor :root, :skip,
                   :project_name, :os_type, # for LXC
                   :arch, :variant, :components, :debian_release, :mirror_url, # for Deb
                   :git_url, :git_options, # for git clone

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -127,13 +127,15 @@ module Haconiwa
 
       opt = parse_opts(args) do |o|
         o.integer('t', 'target', 'PID', "Container's PID to kill.")
+        o.integer('T', 'timeout', 'SECONDS', "Wait time to be killed. Default to (about) 10 sec")
         o.string('s', 'signal', 'SIGFOO', "Signal name. default to TERM")
       end
 
       base, _  = get_script_and_eval(opt.catchall.values)
       base.pid = opt['t'].value if opt['t'].exist?
       signame  = opt['s'].exist? ? opt['s'].value : "TERM"
-      base.kill(signame)
+      timeout  = opt['T'].exist? ? opt['T'].value : 10
+      base.kill(signame, timeout)
     end
 
     def self.watch(args)

--- a/mrblib/haconiwa/provision.rb
+++ b/mrblib/haconiwa/provision.rb
@@ -3,7 +3,7 @@ module Haconiwa
     def initialize
       @ops = []
     end
-    attr_accessor :root, :ops,
+    attr_accessor :root, :ops, :skip,
                   :extra_bind # TODO
 
     class ProvisionOps

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -164,7 +164,7 @@ module Haconiwa
       end
     end
 
-    def kill(sigtype)
+    def kill(sigtype, timeout)
       if !@base.pid
         if File.exist? @base.container_pid_file
           @base.pid = File.read(@base.container_pid_file).to_i
@@ -184,7 +184,7 @@ module Haconiwa
         raise "Invalid or unsupported signal type: #{sigtype}"
       end
 
-      10.times do
+      (timeout * 10).times do
         sleep 0.1
         unless File.exist?(@base.container_pid_file)
           Logger.puts "Kill success"
@@ -192,7 +192,7 @@ module Haconiwa
         end
       end
 
-      Logger.warning "Killing seemd to be failed in 1 second"
+      Logger.warning "Killing seemd to be failed in #{timeout} seconds"
       Process.exit 1
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -11,7 +11,25 @@ module Haconiwa
       end
     end
 
-    def run(init_command)
+    def waitall(&how_you_run)
+      wrap_daemonize do |base, n|
+        pids = how_you_run.call(n)
+
+        if n
+          n.print pids.join(',')
+          n.close
+        end
+
+        while res = ::Process.waitpid2(-1)
+          pid, status = res[0], res[1]
+          pids.delete(pid)
+          Logger.puts "A container finished: #{pid}, #{status.inspect}"
+          break if pids.empty?
+        end
+      end
+    end
+
+    def run(options, init_command)
       if File.exist? @base.container_pid_file
         Logger.err "PID file #{@base.container_pid_file} exists. You may be creating the container with existing name #{@base.name}!"
       end
@@ -19,7 +37,7 @@ module Haconiwa
         @base.init_command = init_command
       end
 
-      wrap_daemonize do |base, notifier|
+      raise_container do |base|
         jail_pid(base)
         # The pipe to set guid maps
         if base.namespace.use_guid_mapping?
@@ -83,9 +101,11 @@ module Haconiwa
         done.close
         persist_namespace(pid, base.namespace)
 
-        if notifier
-          notifier.puts pid.to_s
-          notifier.close # notify container is up
+        base.created_at = Time.now
+        base.pid = pid.to_i
+        base.supervisor_pid = ::Process.pid
+        if @etcd
+          @etcd.put base.etcd_key, base.to_container_json
         end
 
         Logger.puts "Container fork success and going to wait: pid=#{pid}"
@@ -187,28 +207,25 @@ module Haconiwa
 
     private
 
+    def raise_container(&b)
+      b.call(@base)
+    end
+
     def wrap_daemonize(&b)
       if @base.daemon?
-        Logger.info "Container is running in daemon mode"
         r, w = IO.pipe
         ppid = Process.fork do
-          # TODO: logging
           r.close
           ::Procutil.daemon_fd_reopen
           b.call(@base, w)
         end
         w.close
-        pid = r.read
+        _pids = r.read
+        Logger.puts "pids: #{_pids}"
+        pids = _pids.split(',').map{|v| v.to_i }
         r.close
 
-        @base.created_at = Time.now
-        @base.pid = pid.to_i
-        @base.supervisor_pid = ppid
-        if @etcd
-          @etcd.put @base.etcd_key, @base.to_container_json
-        end
-
-        Logger.puts "Container successfully up. PID={container: #{@base.pid}, supervisor: #{@base.supervisor_pid}}"
+        Logger.puts "Container cluster successfully up. PID={supervisors: #{pids.inspect}, root: #{ppid}}"
       else
         b.call(@base, nil)
       end

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -46,7 +46,7 @@ module Haconiwa
     def run_and_wait(pid)
       main = UV::Timer.new
       p = s = nil
-      main.start(100, 100) do
+      main.start(50, 50) do
         p, s = Process.waitpid2(pid, Process::WNOHANG)
         if p
           Logger.puts "Container(#{p}) finish detected: #{s.inspect}"

--- a/sample/multi.haco
+++ b/sample/multi.haco
@@ -38,6 +38,10 @@ apk add --update bash
       c.init_command = ["/bin/sleep", (30 + i*10).to_s]
       c.command.set_stdout(file: "/tmp/test-#{suffix}.stdout")
       c.command.set_stderr(file: "/tmp/test-#{suffix}.stderr")
+
+      if i > 0
+        c.skip_bootstrap
+      end
     end
   end
 end

--- a/sample/multi.haco
+++ b/sample/multi.haco
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  # The first process when invoking haconiwa run:
+  # If your first process is a daemon, please explicitly daemonize by:
+  config.daemonize!
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.chroot_to root
+
+  config.bootstrap do |b|
+    b.strategy = "git"
+    b.git_url = "https://github.com/haconiwa/haconiwa-image-php-tester"
+  end
+
+  config.provision do |p|
+    p.run_shell <<-SHELL
+apk add --update bash
+    SHELL
+  end
+
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  # The namespaces to unshare:
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  3.times do |i|
+    config.define do |c|
+      suffix = UUID.secure_uuid("%x%x")
+      c.name = "haconiwa-#{suffix}"
+      c.init_command = ["/bin/sleep", (30 + i*10).to_s]
+      c.command.set_stdout(file: "/tmp/test-#{suffix}.stdout")
+      c.command.set_stderr(file: "/tmp/test-#{suffix}.stderr")
+    end
+  end
+end

--- a/sample/multi.haco
+++ b/sample/multi.haco
@@ -33,7 +33,7 @@ apk add --update bash
 
   3.times do |i|
     config.define do |c|
-      suffix = UUID.secure_uuid("%x%x")
+      suffix = "child-#{i}"
       c.name = "haconiwa-#{suffix}"
       c.init_command = ["/bin/sleep", (30 + i*10).to_s]
       c.command.set_stdout(file: "/tmp/test-#{suffix}.stdout")

--- a/sample/sleeper001.haco
+++ b/sample/sleeper001.haco
@@ -1,6 +1,6 @@
 # -*- mode: ruby -*-
 Haconiwa.define do |config|
-  suffix = UUID.secure_uuid("%x%x")
+  suffix = ENV["SUFFIX"] || UUID.secure_uuid("%x%x")
 
   # The container name and container's hostname:
   config.name = "haconiwa-#{suffix}"


### PR DESCRIPTION
The example says itself:

```ruby
Haconiwa.define do |config|
  config.daemonize!

  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
  config.chroot_to root

  3.times do |i|
    config.define do |c|
      suffix = UUID.secure_uuid("%x%x")
      c.name = "haconiwa-#{suffix}"
      c.init_command = ["/bin/sleep", (30 + i*10).to_s]
      c.command.set_stdout(file: "/tmp/test-#{suffix}.stdout")
      c.command.set_stderr(file: "/tmp/test-#{suffix}.stderr")
    end
  end
end
```

This implementation may have many bugs, so this is just a small step.