### PR TITLE
Support cgroupv2

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -37,6 +37,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-process-sys', :github => 'haconiwa/mruby-process-sys'
   spec.add_dependency 'mruby-procutil'  , :github => 'haconiwa/mruby-procutil'
   spec.add_dependency 'mruby-resource'  , :github => 'harasou/mruby-resource'
+  spec.add_dependency 'mruby-cgroupv2'  , :github => 'haconiwa/mruby-cgroupv2'
 
   spec.add_dependency 'mruby-syslog'    , :github => 'iij/mruby-syslog'
   spec.add_dependency 'mruby-uv'        , :github => 'mattn/mruby-uv'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -9,6 +9,7 @@ module Haconiwa
                   :filesystem,
                   :resource,
                   :cgroup,
+                  :cgroupv2,
                   :namespace,
                   :capabilities,
                   :guid,
@@ -45,6 +46,7 @@ module Haconiwa
       @filesystem = Filesystem.new
       @resource = Resource.new
       @cgroup = CGroup.new
+      @cgroupv2 = CGroupV2.new
       @namespace = Namespace.new
       @capabilities = Capabilities.new
       @guid = Guid.new
@@ -81,6 +83,18 @@ module Haconiwa
 
     def rootfs
       filesystem.rootfs
+    end
+
+    def cgroup(v=nil, &blk)
+      cg = if v.to_s == "v2"
+             @cgroupv2
+           else
+             @cgroup
+           end
+      if blk
+        blk.call(cg)
+      end
+      cg
     end
 
     def add_mount_point(point, options)
@@ -273,6 +287,15 @@ module Haconiwa
       @groups_by_controller.keys.uniq
     end
     alias controllers to_controllers
+  end
+
+  class CGroupV2 < CGroup
+    def []=(key, value)
+      @groups[key] = value
+      c, *attr = key.split('.')
+      raise("Invalid cgroup name #{key}") if attr.empty?
+      return value
+    end
   end
 
   class Capabilities

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -324,7 +324,7 @@ module Haconiwa
       unless base.cgroupv2.groups.empty?
         cg = ::CgroupV2.new_group(base.name)
         cg.create
-        base.cgroupv2.groups.each_pair do |key, value|
+        base.cgroupv2.groups.each do |key, value|
           cg[key.to_s] = value.to_s
         end
         cg.commit

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -320,6 +320,16 @@ module Haconiwa
         c.create
         c.attach
       end
+
+      unless base.cgroupv2.groups.empty?
+        cg = ::CgroupV2.new_group(base.name)
+        cg.create
+        base.cgroupv2.groups.each_pair do |key, value|
+          cg[key.to_s] = value.to_s
+        end
+        cg.commit
+        cg.attach
+      end
     end
 
     def cleanup_cgroup(base)

--- a/sample/cgroup.haco
+++ b/sample/cgroup.haco
@@ -6,7 +6,7 @@ haconiwa = Haconiwa.define do |config|
   config.init_command = ["/usr/sbin/sshd", '-D'] # to be first process
   config.daemonize!
 
-  root = Pathname.new("/var/lib/haconiwa/2a1042d9")
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
   config.mount_independent "procfs"
   config.mount_independent "sysfs"
   config.mount_independent "devtmpfs"
@@ -48,11 +48,16 @@ haconiwa = Haconiwa.define do |config|
         File.open("/tmp/log_#{b.name}.txt", "a+") {|f| f.puts "Changed cpu.cfs_quota_us = #{cpu.cfs_quota_us}" }
       end
     end
-  elsif ENV['CGROUP'] = 'memory'
+  elsif ENV['CGROUP'] == 'memory'
     config.cgroup["memory.limit_in_bytes"] = 128 * 1024 * 1024 # 128MB
     config.cgroup["memory.memsw.limit_in_bytes"] = 128 * 1024 * 1024 # 128MB
+  elsif ENV['CGROUP'] == 'io'
+    config.cgroup :v2 do |cgroup|
+      cgroup["io.max"] = "8:0 rbps=#{1024 ** 2} wbps=#{1024 ** 2}"
+    end
   end
 
   # sshd needs chroot!
   config.capabilities.allow "cap_sys_chroot"
+  config.capabilities.allow "cap_kill"
 end


### PR DESCRIPTION
This PR enable Haconiwa to access and control resources via [cgroup-v2](https://www.kernel.org/doc/Documentation/cgroup-v2.txt) filesystem.

My image of DSL spec:

```ruby
config.cgroup do |cgroup|
  cgroup["pids.max"] = 1024
  # ...
end

config.cgroup :v2 do |cgroup|
  cgroup["io.max"] = "8:0 rbps=1048576 wbps=1048576"
end
#...
```