### PR TITLE
Forwardport of detailed syslog logger

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -17,6 +17,8 @@ end
 MRuby::Build.new('x86_64-pc-linux-gnu') do |conf|
   toolchain :gcc
 
+  conf.enable_debug
+
   gem_config(conf)
 end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -222,6 +222,10 @@ module Haconiwa
           pid
         end
       end
+    rescue HacoFatalError => e
+      raise e
+    rescue => e
+      Logger.exception(e)
     end
     alias run start
 

--- a/mrblib/haconiwa/exception.rb
+++ b/mrblib/haconiwa/exception.rb
@@ -1,0 +1,4 @@
+module Haconiwa
+  class HacoFatalError < RuntimeError
+  end
+end

--- a/mrblib/haconiwa/logger.rb
+++ b/mrblib/haconiwa/logger.rb
@@ -9,9 +9,21 @@ module Haconiwa
     end
 
     # Calling this will stop haconiwa process
+    def exception(*args)
+      if args.first.is_a? HacoFatalError
+        e = args.first
+        Syslog.err("An exception is occurred when spawning haconiwa:")
+        Syslog.err("#{e.inspect}")
+        Syslog.err("...Shutting down haconiwa")
+        raise(e)
+      else
+        Syslog.err(*args)
+        raise(HacoFatalError, *args)
+      end
+    end
+
     def err(*args)
       Syslog.err(*args)
-      raise(*args)
     end
 
     # Warning is forced to be teed to stderr

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -31,7 +31,7 @@ module Haconiwa
 
     def run(options, init_command)
       if File.exist? @base.container_pid_file
-        Logger.err "PID file #{@base.container_pid_file} exists. You may be creating the container with existing name #{@base.name}!"
+        Logger.exception "PID file #{@base.container_pid_file} exists. You may be creating the container with existing name #{@base.name}!"
       end
       unless init_command.empty?
         @base.init_command = init_command
@@ -47,39 +47,44 @@ module Haconiwa
         done, kick_ok = IO.pipe
 
         pid = Process.fork do
-          ::Procutil.mark_cloexec
-          [r, w2].each {|io| io.close if io }
-          done.close
-          ::Procutil.setsid if base.daemon?
+          begin
+            ::Procutil.mark_cloexec
+            [r, w2].each {|io| io.close if io }
+            done.close
+            ::Procutil.setsid if base.daemon?
 
-          apply_namespace(base.namespace)
-          apply_filesystem(base)
-          apply_rlimit(base.resource)
-          apply_cgroup(base)
-          apply_remount(base)
-          ::Procutil.sethostname(base.name)
+            apply_namespace(base.namespace)
+            apply_filesystem(base)
+            apply_rlimit(base.resource)
+            apply_cgroup(base)
+            apply_remount(base)
+            ::Procutil.sethostname(base.name)
 
-          apply_user_namespace(base.namespace)
-          if base.namespace.use_guid_mapping?
-            # ping and pong between parent
-            w.puts "unshared"
-            w.close
+            apply_user_namespace(base.namespace)
+            if base.namespace.use_guid_mapping?
+              # ping and pong between parent
+              w.puts "unshared"
+              w.close
 
-            r2.read
-            r2.close
-            switch_current_namespace_root
+              r2.read
+              r2.close
+              switch_current_namespace_root
+            end
+
+            do_chroot(base)
+            reopen_fds(base.command) if base.daemon?
+
+            apply_capability(base.capabilities)
+            switch_guid(base.guid)
+            kick_ok.puts "done"
+            kick_ok.close
+
+            Logger.info "Container is going to exec: #{base.init_command.inspect}"
+            Exec.execve(base.environ, *base.init_command)
+          rescue => e
+            Logger.exception(e)
+            exit(127)
           end
-
-          do_chroot(base)
-          reopen_fds(base.command) if base.daemon?
-
-          apply_capability(base.capabilities)
-          switch_guid(base.guid)
-          kick_ok.puts "done"
-          kick_ok.close
-
-          Logger.info "Container is going to exec: #{base.init_command.inspect}"
-          Exec.execve(base.environ, *base.init_command)
         end
         base.pid = pid
         kick_ok.close
@@ -129,7 +134,7 @@ module Haconiwa
         if File.exist? base.container_pid_file
           base.pid = File.read(base.container_pid_file).to_i
         else
-          Logger.err "PID file #{base.container_pid_file} doesn't exist. You may be specifying container PID by -t option"
+          Logger.exception "PID file #{base.container_pid_file} doesn't exist. You may be specifying container PID by -t option"
         end
       end
 
@@ -219,9 +224,14 @@ module Haconiwa
       if @base.daemon?
         r, w = IO.pipe
         ppid = Process.fork do
-          r.close
-          ::Procutil.daemon_fd_reopen
-          b.call(@base, w)
+          begin
+            # TODO: logging
+            r.close
+            ::Procutil.daemon_fd_reopen
+            b.call(@base, w)
+          rescue => e
+            Logger.exception(e)
+          end
         end
         w.close
         _pids = r.read
@@ -247,13 +257,13 @@ module Haconiwa
               0
             end
       if ret < 0
-        Logger.err "Unsharing or setting PID namespace failed"
+        Logger.exception "Unsharing or setting PID namespace failed"
       end
     end
 
     def apply_namespace(namespace)
       if ::Namespace.unshare(namespace.to_flag_for_unshare) < 0
-        Logger.err "Some namespace is unsupported by this kernel. Please check"
+        Logger.exception "Some namespace is unsupported by this kernel. Please check"
       end
 
       if namespace.setns_on_run?
@@ -262,7 +272,7 @@ module Haconiwa
           next if ns == ::Namespace::CLONE_NEWUSER
           f = File.open(path)
           if ::Namespace.setns(ns, fd: f.fileno) < 0
-            Logger.err "Some namespace is unsupported by this kernel. Please check"
+            Logger.exception "Some namespace is unsupported by this kernel. Please check"
           end
           f.close
         end
@@ -330,7 +340,7 @@ module Haconiwa
     def apply_cgroup(base)
       base.cgroup.controllers.each do |controller|
         Logger.debug "Creating cgroup controller #{controller}"
-        Logger.err("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
+        Logger.exception("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
 
         c = CG_MAPPING[controller].new(base.name)
         base.cgroup.groups_by_controller[controller].each do |pair|
@@ -355,7 +365,7 @@ module Haconiwa
 
     def cleanup_cgroup(base)
       base.cgroup.controllers.each do |controller|
-        Logger.err("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
+        Logger.exception("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
 
         c = CG_MAPPING[controller].new(base.name)
         c.delete
@@ -381,7 +391,7 @@ module Haconiwa
       end
     rescue => e
       showid = capabilities.acts_as_whitelist? ? capabilities.whitelist_ids : capabilities.blacklist_ids
-      Logger.err "Maybe there are unsupported caps in #{showid.inspect}: #{e.class} - #{e.message}"
+      Logger.exception "Maybe there are unsupported caps in #{showid.inspect}: #{e.class} - #{e.message}"
     end
 
     def apply_rlimit(rlimit)


### PR DESCRIPTION
This patch includes Ruby-level exception logger. See #72 :)

I tried in real binary:

```
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[2044]: Base setting DSL is evaluated
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[2044]: pids: 2046
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[2044]: Container cluster successfully up. PID={supervisors: [2046], root: 2045}
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[1]: Container is going to exec: ["/bin/bass"]
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[1]: execve failed
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[1]: An exception is occurred when spawning haconiwa:
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[1]: /Users/udzura/.ghq/github.com/haconiwa/haconiwa/mrblib/haconiwa/logger.rb:21: execve failed (Haconiwa::HacoFatalError)
Jan 30 06:42:39 udzura haconiwa.haconiwa-1b8fb27[1]: ...Shutting down haconiwa
```