### PR TITLE
General hooks in container spawning process 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ e.g. just using `mount` namespace unshared, container with common filesystem, li
 
 #### Hooks
 
+* `config.add_general_hook` - Define hook codes that are invoked through the Haconiwa's spawning process. Hook points are below:
+  * `:before_fork` - Hooked just before the container process is forked
+  * `:after_fork` - Hooked just after the container process is forked, in forked process
+  * `:before_chroot` - Hooked just after container settins are applied (e.g. namespace, cgroup, caps, fs mounting) and just before do chroot in forked process
+  * `:after_chroot` - Hooked just after the chroot is successful, in forked process. This is the last timing before doing `exec()` and becoming a new program
+  * `:before_start_wait` - Hooked before starting to `wait()` the container process. Hook itself is invoked in the parent process
+  * `:teardown` - Hooked after the container process has quitted, in the parent process
+  * Every hook can accept one argument `base`, which is Haconiwa::Base object.
 * `config.after_spawn(option, &block)` - Define timer handler. Pass option like `msec: 10 * 60 * 1000`, then after 10 min passed, the defined hook will be invoked
 * `config.add_signal_handler(signame, &block)` - Define signal handler at supervisor process(not container itself). Available signals are `SIGTTIN/SIGTTOU/SIGUSR1/SIGUSR2`. See [handler example](./sample/cpu.haco).
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -22,7 +22,8 @@ module Haconiwa
                   :created_at,
                   :etcd_name,
                   :network_mountpoint,
-                  :cleaned
+                  :cleaned,
+                  :exit_status
 
     attr_reader   :waitloop
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -392,6 +392,10 @@ module Haconiwa
       @namespaces[flag] = options
     end
 
+    def flag?(flag)
+      @namespaces.has_key? to_bit(flag)
+    end
+
     def active_namespaces
       @namespaces.keys
     end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -122,6 +122,7 @@ module Haconiwa
     end
 
     def add_general_hook(hookpoint, &b)
+      raise("Invalid hook point: #{hookpoint.inspect}") unless LinuxRunner::VALID_HOOKS.include?(hookpoint.to_sym)
       @general_hooks[hookpoint.to_sym] = b
     end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -13,6 +13,7 @@ module Haconiwa
                   :namespace,
                   :capabilities,
                   :guid,
+                  :general_hooks,
                   :environ,
                   :attached_capabilities,
                   :signal_handler,
@@ -50,6 +51,7 @@ module Haconiwa
       @namespace = Namespace.new
       @capabilities = Capabilities.new
       @guid = Guid.new
+      @general_hooks = {}
       @environ = {}
       @signal_handler = SignalHandler.new
       @attached_capabilities = nil
@@ -116,6 +118,10 @@ module Haconiwa
       from = options[:host_root] || '/etc'
       self.network_mountpoint << MountPoint.new("#{from}/resolv.conf", to: "#{root}/etc/resolv.conf")
       self.network_mountpoint << MountPoint.new("#{from}/hosts",       to: "#{root}/etc/hosts")
+    end
+
+    def add_general_hook(hookpoint, &b)
+      @general_hooks[hookpoint.to_sym] = b
     end
 
     def add_signal_handler(sig, &b)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -11,6 +11,15 @@ module Haconiwa
       end
     end
 
+    VALID_HOOKS = [
+      :before_fork,
+      :after_fork,
+      :before_chroot,
+      :after_chroot,
+      :before_start_wait,
+      :teardown,
+    ]
+
     def run(init_command)
       if File.exist? @base.container_pid_file
         Logger.exception "PID file #{@base.container_pid_file} exists. You may be creating the container with existing name #{@base.name}!"

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -107,6 +107,9 @@ module Haconiwa
 
         invoke_general_hook(:before_start_wait, base)
         pid, status = base.waitloop.run_and_wait(pid)
+        base.exit_status = status
+        invoke_general_hook(:teardown, base)
+
         cleanup_supervisor(base, @etcd)
         if status.success?
           Logger.puts "Container successfully exited: #{status.inspect}"

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -255,8 +255,8 @@ module Haconiwa
       hook = base.general_hooks[hookpoint]
       hook.call(base) if hook
     rescue => e
-      Logger.warn("General container hook at #{hookpoint.inspect} failed. Skip")
-      Logger.warn("#{e.class} - #{e.message}")
+      Logger.warning("General container hook at #{hookpoint.inspect} failed. Skip")
+      Logger.warning("#{e.class} - #{e.message}")
     end
 
     def apply_namespace(namespace)

--- a/sample/hooks.haco
+++ b/sample/hooks.haco
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
+IKACHAN_HOST = ENV['IKACHAN_HOST'] || "ikachan.local:4979"
 def slack(msg)
-  system "curl -d message='#{msg}' -d channel='#haconiwa-dev' ikachan.local:4979/notice"
+  http = HttpRequest.new
+  http.post(
+    "http://#{IKACHAN_HOST}/notice",
+    {message: msg, channel: '#test'},
+    {"Content-Type" => 'application/x-www-form-urlencoded', 'User-Agent' => "Haconiwa v#{Haconiwa::VERSION}"}
+  )
 end
 
 Haconiwa.define do |config|
@@ -17,6 +23,10 @@ Haconiwa.define do |config|
 
   config.add_general_hook :before_start_wait do |base|
     slack("Container is UP!! Everything is OK!!1 #{base.name}")
+  end
+
+  config.add_general_hook :teardown do |base|
+    slack("Container is Exited. #{base.name} => #{base.exit_status.inspect}")
   end
 
   config.add_general_hook :after_fork do |base|

--- a/sample/hooks.haco
+++ b/sample/hooks.haco
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+def slack(msg)
+  system "curl -d message='#{msg}' -d channel='#haconiwa-dev' ikachan.local:4979/notice"
+end
+
+Haconiwa.define do |config|
+  # The container name and container's hostname:
+  config.name = "hooks-test"
+  # The first process when invoking haconiwa run:
+  config.init_command = ["/bin/sleep", (ENV['SLEEP'] || (30 + (UUID.secure_uuid("%d").to_i / 256).floor).to_s)]
+  # If your first process is a daemon, please explicitly daemonize by:
+  config.daemonize!
+
+  config.add_general_hook :before_fork do |base|
+    slack("Container is being created... #{base.name}")
+  end
+
+  config.add_general_hook :before_start_wait do |base|
+    slack("Container is UP!! Everything is OK!!1 #{base.name}")
+  end
+
+  config.add_general_hook :after_fork do |base|
+    slack("Container is forked!! #{base.name}")
+  end
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.chroot_to root
+
+  config.bootstrap do |b|
+    b.strategy = "git"
+    b.git_url = "https://github.com/haconiwa/haconiwa-image-php-tester"
+  end
+
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+end

--- a/sample/hooks.haco
+++ b/sample/hooks.haco
@@ -26,11 +26,18 @@ Haconiwa.define do |config|
   end
 
   config.add_general_hook :teardown do |base|
-    slack("Container is Exited. #{base.name} => #{base.exit_status.inspect}")
+    hostname = `hostname`.chomp
+    slack("Container is Exited. #{base.name} => #{base.exit_status.inspect}, current hostname: #{hostname}")
   end
 
   config.add_general_hook :after_fork do |base|
-    slack("Container is forked!! #{base.name}")
+    hostname = `hostname`.chomp
+    slack("Container is forked!! #{base.name}, current hostname: #{hostname}")
+  end
+
+  config.add_general_hook :after_chroot do |base|
+    hostname = `hostname`.chomp
+    slack("Container is going to be done!! #{base.name}, current hostname: #{hostname}")
   end
 
   root = Pathname.new("/var/lib/haconiwa/8cfccb3d")


### PR DESCRIPTION
## Abstract

This patch is making Haconiwa more programmable container framework. This adds hooks:

* before_fork
* after_fork(in child)
* before_chroot(in child)
* after_chroot(in child. This is the last timing before `exec`)
* before_start_wait
* teardown

## TODOs

* [x] Add documents

## To be discussed

* More hooks to be required
* Good name(general... what is general)

## The FIXME point -> ✅ FIXED

* ~~Because PID namespace is jailed, we cannot call `fork` on some hook(especially on teardown), this means functions like `Kernel#system` are unavailable at these timing. This will be fixed by using `Namespace.clone` instead of `Process.fork`, which looks unstable...~~