### PR TITLE
Do not update hostname when UTS namespace not activated

### DIFF
--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -62,7 +62,7 @@ module Haconiwa
             apply_rlimit(base.resource)
             apply_cgroup(base)
             apply_remount(base)
-            ::Procutil.sethostname(base.name)
+            ::Procutil.sethostname(base.name) if base.namespace.flag?(::Namespace::CLONE_NEWUTS)
 
             apply_user_namespace(base.namespace)
             if base.namespace.use_guid_mapping?


### PR DESCRIPTION
When you use haconiwa as advanced chroot tool, there is unexpected side-effect...