### PR TITLE
Skip chroot if no definition of chroot_to

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -517,7 +517,7 @@ module Haconiwa
 
   class Rootfs
     def initialize(rootpath, options={})
-      @root = rootpath.to_str
+      @root = rootpath.to_str if rootpath
       @owner_uid = options[:owner_uid] || 0
       @owner_gid = options[:owner_gid] || 0
     end
@@ -539,6 +539,7 @@ module Haconiwa
     def initialize
       @mount_points = []
       @independent_mount_points = []
+      @rootfs = Rootfs.new(nil)
     end
     attr_accessor :mount_points,
                   :independent_mount_points,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -441,8 +441,12 @@ module Haconiwa
     end
 
     def do_chroot(base)
-      Dir.chdir File.expand_path([base.filesystem.chroot, base.workdir].join('/'))
-      Dir.chroot base.filesystem.chroot
+      if base.filesystem.chroot
+        Dir.chdir File.expand_path([base.filesystem.chroot, base.workdir].join('/'))
+        Dir.chroot base.filesystem.chroot
+      else
+        Dir.chdir base.workdir
+      end
     end
 
     def switch_current_namespace_root


### PR DESCRIPTION
This means you can even skip chroot'ing. Invoke processes only for namespace or cgroup, &c ;)