### PR TITLE
Ensure `kill` waits until the super-supervisor process exits

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -11,7 +11,6 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-bin-mruby' , :core => 'mruby-bin-mruby'
   #spec.add_dependency 'mruby-bin-mirb'  , :core => 'mruby-bin-mirb'
   spec.add_dependency 'mruby-eval'      , :core => 'mruby-eval'
-  spec.add_dependency 'mruby-print'     , :core => 'mruby-print'
   spec.add_dependency 'mruby-random'    , :core => 'mruby-random'
   spec.add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
   spec.add_dependency 'mruby-time'      , :core => 'mruby-time'
@@ -46,6 +45,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
 
   # The good luck charm for avoiding dependency hell
   spec.add_dependency 'mruby-sprintf'   , :core => 'mruby-sprintf'
+  spec.add_dependency 'mruby-print'     , :core => 'mruby-print'
 
   def spec.save_dependent_mgem_revisions
     file DEFS_FILE do

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -38,8 +38,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
 
   spec.add_dependency 'mruby-syslog'    , :github => 'iij/mruby-syslog'
   spec.add_dependency 'mruby-timer-thread' , :github => 'matsumotory/mruby-timer-thread'
-  spec.add_dependency 'mruby-signal-thread', :github => 'pyama86/mruby-signal-thread',
-                      :checksum_hash => 'fd477b13413ad4f536b7c16d47976b64b3f9012f'
+  spec.add_dependency 'mruby-signal-thread', :github => 'pyama86/mruby-signal-thread'
 
   spec.add_test_dependency 'mruby-tempfile', :github => 'iij/mruby-tempfile'
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -267,12 +267,14 @@ module Haconiwa
       containers_real_run.each do |c|
         c.kill(signame, timeout)
       end
-    end
 
-    Timeout.timeout 3 do
-      while File.exist? supervisor_all_pid_file
-        usleep 1000
+      30.times do
+        unless File.exist? supervisor_all_pid_file
+          return true
+        end
+        usleep 100 * 1000
       end
+      raise "Kill does not seem to be completed. Check process of PID=#{::File.read supervisor_all_pid_file}"
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -268,7 +268,7 @@ module Haconiwa
         c.kill(signame, timeout)
       end
 
-      30.times do
+      (timeout * 10).times do
         unless File.exist? supervisor_all_pid_file
           return true
         end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -86,6 +86,11 @@ module Haconiwa
       end
     end
 
+    def supervisor_all_pid_file
+      names = containers_real_run.map{|b| b.name }.join('-')
+      "/var/run/haconiwa-parent-#{names}.pid"
+    end
+
     def init_command=(cmd)
       self.command.init_command = cmd
     end
@@ -261,6 +266,12 @@ module Haconiwa
     def kill(signame, timeout)
       containers_real_run.each do |c|
         c.kill(signame, timeout)
+      end
+    end
+
+    Timeout.timeout 3 do
+      while File.exist? supervisor_all_pid_file
+        usleep 1000
       end
     end
   end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -264,9 +264,12 @@ module Haconiwa
             b.call(@base, w)
           rescue => e
             Logger.exception(e)
+          ensure
+            File.unlink @base.supervisor_all_pid_file
           end
         end
         w.close
+        File.open(@base.supervisor_all_pid_file, 'w') {|f| f.write ppid }
         _pids = r.read
         Logger.puts "pids: #{_pids}"
         pids = _pids.split(',').map{|v| v.to_i }

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -234,7 +234,7 @@ module Haconiwa
         end
       end
 
-      Logger.warning "Killing seemd to be failed in #{timeout} seconds"
+      Logger.warning "Killing seemd to be failed in #{timeout} seconds. Check out process PID=#{@base.pid}"
       Process.exit 1
     end
 


### PR DESCRIPTION
Added parent's PID file, and then use this file to wait.