### PR TITLE
Point mruby-thread to mgem again

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -38,7 +38,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-syslog'    , :github => 'iij/mruby-syslog'
   spec.add_dependency 'mruby-timer-thread' , :github => 'matsumotory/mruby-timer-thread'
   spec.add_dependency 'mruby-signal-thread', :github => 'pyama86/mruby-signal-thread'
-  spec.add_dependency 'mruby-thread', :github => 'udzura/mruby-thread', :branch => 'fix-symbol-bug'
+  spec.add_dependency 'mruby-thread', :mgem => 'mruby-thread'
 
   spec.add_test_dependency 'mruby-tempfile', :github => 'iij/mruby-tempfile'
   spec.add_test_dependency 'mruby-cache', :github => 'matsumotory/mruby-localmemcache'


### PR DESCRIPTION
Since https://github.com/mattn/mruby-thread/pull/47 is merged.