### PR TITLE
Support seccomp filter DSL

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -24,6 +24,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-linux-namespace', :mgem => 'mruby-linux-namespace'
   spec.add_dependency 'mruby-process'   , :github => 'iij/mruby-process'
   spec.add_dependency 'mruby-socket'    , :mgem => 'mruby-socket'
+  spec.add_dependency 'mruby-seccomp'   , :mgem => 'mruby-seccomp'
 
   spec.add_dependency 'mruby-onig-regexp', :github => 'udzura/mruby-onig-regexp'
   spec.add_dependency 'mruby-argtable'  , :github => 'udzura/mruby-argtable', :branch => 'static-link-argtable3'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -13,6 +13,7 @@ module Haconiwa
                   :namespace,
                   :capabilities,
                   :guid,
+                  :seccomp,
                   :general_hooks,
                   :async_hooks,
                   :environ,
@@ -64,6 +65,7 @@ module Haconiwa
       @namespace = Namespace.new
       @capabilities = Capabilities.new
       @guid = Guid.new
+      @seccomp = Seccomp.new
       @general_hooks = {}
       @async_hooks = []
       @environ = {}
@@ -316,6 +318,7 @@ module Haconiwa
         :@namespace,
         :@capabilities,
         :@guid,
+        :@seccomp,
         :@general_hooks,
         :@async_hooks,
         :@environ,
@@ -726,6 +729,20 @@ module Haconiwa
         end
       end
       @groups
+    end
+  end
+
+  class Seccomp
+    def initialize
+      @def_action = nil
+      @defblock = nil
+    end
+    attr_accessor :def_action, :defblock
+
+    def filter(options={}, &blk)
+      @def_action = options[:default]
+      raise("default: must be specified to filter") unless @def_action
+      @defblock = blk
     end
   end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -119,6 +119,7 @@ module Haconiwa
             reopen_fds(base.command) if base.daemon?
 
             apply_capability(base.capabilities)
+            apply_seccomp(base.seccomp)
             switch_guid(base.guid)
             kick_ok.puts "done"
             kick_ok.close
@@ -490,6 +491,14 @@ module Haconiwa
     rescue => e
       showid = capabilities.acts_as_whitelist? ? capabilities.whitelist_ids : capabilities.blacklist_ids
       Logger.exception "Maybe there are unsupported caps in #{showid.inspect}: #{e.class} - #{e.message}"
+    end
+
+    def apply_seccomp(seccomp)
+      if seccomp.def_action
+        ctx = ::Seccomp.new(default: seccomp.def_action)
+        seccomp.defblock.call(ctx)
+        ctx.load
+      end
     end
 
     def apply_rlimit(rlimit)

--- a/sample/seccomp.haco
+++ b/sample/seccomp.haco
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  config.name = "haconiwa-seccomp-test"
+  # invoke shell that cannot call mkdir(1) or chown(1)
+  config.init_command = ["/bin/sh"]
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.chroot_to root
+
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  # The namespaces to unshare:
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  config.seccomp.filter(default: :allow) do |rule|
+    rule.kill :mkdir
+    rule.kill :fchownat
+  end
+end


### PR DESCRIPTION
DSL spec:

```ruby
config.seccomp.filter(default: :allow) do |rule|
  rule.kill(:chroot)
end

# if specified
config.capabilities.allow 'cap_sys_chroot'
```

Then, you cannot invoke `chroot(2)` even if you have capabilities.

(This may be available in CentOS 7 (kernel 3.10) / Ubuntu xenial (kernel 4.4) ...)