### PR TITLE
Making proper behavior when haconiwa binary is set-user-id root'ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ e.g. just using `mount` namespace unshared, container with common filesystem, li
   * `:interval_msec` - Define the interval timeout hooks, if this paramete exists.
   * NOTE: Async hook uses POSIX timer and real-time signals internally. Please do not queue real-time signals directly.
 * `config.add_signal_handler(signame, &block)` - Define signal handler at supervisor process(not container itself). Available signals are `SIGTTIN/SIGTTOU/SIGUSR1/SIGUSR2`. See [handler example](./sample/cpu.haco).
+* `config.validate_real_id(&block{|ruid, rgid| ... })` - Validates the Real UID/GID who invoked haconiwa command. return true if OK, false/nil to mark invalid. This is useful when haconiwa command is set-user-ID root
 
 Please check out [`sample`](./sample) directory.
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -44,7 +44,6 @@ module Haconiwa
       Logger.info("Base setting DSL is evaluated")
       barn
     end
-    attr_accessor :system_exception
 
     def define(&b)
       base = Base.new(self)
@@ -84,7 +83,12 @@ module Haconiwa
 
       @containers = []
     end
+    attr_accessor :system_exception, :rid_validator
     attr_reader :containers, :waitloop
+
+    def validate_real_id(&validator)
+      @rid_validator = validator
+    end
 
     def containers_real_run
       if containers.empty?

--- a/mrblib/haconiwa/logger.rb
+++ b/mrblib/haconiwa/logger.rb
@@ -17,6 +17,10 @@ module Haconiwa
         e.backtrace[1..-1].each{|l| Syslog.err "=> #{l}" } if e.backtrace
         Syslog.err("...Shutting down haconiwa")
         raise(e)
+      elsif args.first.is_a? Exception
+        Syslog.err("#{e.inspect}")
+        Syslog.err("=> #{e.backtrace.first}") if e.backtrace
+        raise(HacoFatalError, e.inspect)
       else
         Syslog.err(*args)
         raise(HacoFatalError, *args)

--- a/mrblib/haconiwa/logger.rb
+++ b/mrblib/haconiwa/logger.rb
@@ -18,6 +18,7 @@ module Haconiwa
         Syslog.err("...Shutting down haconiwa")
         raise(e)
       elsif args.first.is_a? Exception
+        e = args.first
         Syslog.err("#{e.inspect}")
         Syslog.err("=> #{e.backtrace.first}") if e.backtrace
         raise(HacoFatalError, e.inspect)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -47,12 +47,12 @@ module Haconiwa
         invoke_general_hook(:teardown, barn)
       end
     rescue HacoFatalError => ex
-      barn.system_exception = ex
-      invoke_general_hook(:system_failure, barn)
+      @base.system_exception = ex
+      invoke_general_hook(:system_failure, @base)
       raise ex
     rescue => e
-      barn.system_exception = e
-      invoke_general_hook(:system_failure, barn)
+      @base.system_exception = e
+      invoke_general_hook(:system_failure, @base)
       Logger.exception(e)
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -551,14 +551,11 @@ module Haconiwa
     end
 
     def switch_guid(guid)
-      if guid.gid
-        ::Process::Sys.setgid(guid.gid)
-        ::Process::Sys.__setgroups(guid.groups + [guid.gid])
-      else
-        # Assume gid is same as uid
-        ::Process::Sys.setgid(guid.uid) if guid.uid
-      end
-      ::Process::Sys.setuid(guid.uid) if guid.uid
+      uid = guid.uid || ::Process::Sys.getuid
+      gid = guid.gid || ::Process::Sys.getgid
+      ::Process::Sys.setgid(guid.gid)
+      ::Process::Sys.__setgroups(guid.groups + [guid.gid])
+      ::Process::Sys.setuid(uid)
     end
 
     def persist_namespace(pid, namespace)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -555,8 +555,8 @@ module Haconiwa
     def switch_guid(guid)
       uid = guid.uid || ::Process::Sys.getuid
       gid = guid.gid || ::Process::Sys.getgid
-      ::Process::Sys.setgid(guid.gid)
-      ::Process::Sys.__setgroups(guid.groups + [guid.gid])
+      ::Process::Sys.setgid(gid)
+      ::Process::Sys.__setgroups(guid.groups + [gid])
       ::Process::Sys.setuid(uid)
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -5,6 +5,7 @@ module Haconiwa
   class LinuxRunner < Runner
     def initialize(base)
       @base = base
+      validate_ruid(base)
     end
 
     VALID_HOOKS = [
@@ -276,6 +277,14 @@ module Haconiwa
         File.unlink base.container_pid_file
       end
       base.cleaned = true
+    end
+
+    def validate_ruid(base)
+      if base.rid_validator
+        unless base.rid_validator.call(::Process::Sys.getuid, ::Process::Sys.getgid)
+          raise "Invalid user/group to invoke suid-haconiwa: #{::Process::Sys.getuid}:#{::Process::Sys.getgid}"
+        end
+      end
     end
 
     private

--- a/sample/sshd.haco
+++ b/sample/sshd.haco
@@ -12,8 +12,8 @@ Haconiwa.define do |config|
   config.add_mount_point "/var/haconiwa/user_homes", to: root + "/home/haconiwa"
   config.chroot_to root
 
-  config.uid = 'vagrant'
-  config.gid = 'vagrant'
+  #config.uid = 'vagrant'
+  #config.gid = 'vagrant'
 
   config.mount_independent "procfs"
   config.mount_independent "sysfs"

--- a/sample/sshd.haco
+++ b/sample/sshd.haco
@@ -4,17 +4,24 @@ Haconiwa.define do |config|
   config.init_command = ["/usr/sbin/sshd", '-D'] # to be first process
   config.daemonize!
 
-  root = "/var/haconiwa/root/"
-  config.add_mount_point "/var/lib/haconiwa", to: root, readonly: true
-  config.add_mount_point "/lib64", to: root + "lib64", readonly: true
-  config.add_mount_point "/usr/bin", to: root + "usr/bin", readonly: true
-  config.add_mount_point "/usr/sbin", to: root + "usr/sbin", readonly: true
-  config.add_mount_point "tmpfs",  to: root + "tmp", fs: "tmpfs"
-  config.add_mount_point "devpts", to: root + "dev/pts", fs: "devpts"
-  config.add_mount_point "/var/haconiwa/user_homes", to: root + "home/haconiwa"
-  config.mount_independent_procfs
+  root = "/var/lib/haconiwa/8cfccb3d"
+  # config.add_mount_point "/lib64", to: root + "/lib64", readonly: true
+  # config.add_mount_point "/usr/bin", to: root + "/usr/bin", readonly: true
+  # config.add_mount_point "/usr/sbin", to: root + "/usr/sbin", readonly: true
+  config.add_mount_point "tmpfs",  to: root + "/tmp", fs: "tmpfs"
+  config.add_mount_point "/var/haconiwa/user_homes", to: root + "/home/haconiwa"
   config.chroot_to root
 
+  config.uid = 'vagrant'
+  config.gid = 'vagrant'
+
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  # The namespaces to unshare:
   config.namespace.unshare "mount"
   config.namespace.unshare "ipc"
   config.namespace.unshare "uts"
@@ -23,5 +30,6 @@ Haconiwa.define do |config|
   config.cgroup["cpu.cfs_quota_us"] = 30000
   config.cgroup["cpuset.cpus"] = "0"
 
-  config.capabilities.drop 'cap_sys_time'
+  config.capabilities.allow 'cap_sys_chroot'
+  config.capabilities.allow 'cap_kill'
 end


### PR DESCRIPTION
* Set container's euid to haconiwa supervisor's ruid
* Validate the ruid to run haconiwa
* Return euid to ruid when containers have been spawned