### PR TITLE
Avoid File.expand_path

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -817,7 +817,7 @@ module Haconiwa
       elsif %w(tmpfs devtmpfs proc sysfs devpts).include?(@fs.to_s)
         @src
       else
-        fullpath = File.expand_path [cwd, @src].join("/")
+        fullpath = ExpandPath.expand [cwd, @src].join("/")
         File.exist?(fullpath) ? fullpath : @src
       end
     end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -813,6 +813,9 @@ module Haconiwa
     def normalized_src(cwd="/")
       if @src.start_with?('/')
         @src
+      # These filesystems do not need a real src directory
+      elsif %w(tmpfs devtmpfs proc sysfs devpts).include?(@fs.to_s)
+        @src
       else
         fullpath = File.expand_path [cwd, @src].join("/")
         File.exist?(fullpath) ? fullpath : @src

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -203,7 +203,7 @@ module Haconiwa
     def self.get_base(args)
       script = File.read(args[0])
       obj = Kernel.eval(script)
-      obj.hacofile = (args[0][0] == '/') ? args[0] : File.expand_path(args[0], Dir.pwd)
+      obj.hacofile = (args[0][0] == '/') ? args[0] : ExpandPath.expand(args[0], Dir.pwd)
       return obj
     end
 
@@ -214,7 +214,7 @@ module Haconiwa
         exe.shift
       end
       obj = Kernel.eval(script)
-      obj.hacofile = (args[0][0] == '/') ? args[0] : File.expand_path(args[0], Dir.pwd)
+      obj.hacofile = (args[0][0] == '/') ? args[0] : ExpandPath.expand(args[0], Dir.pwd)
 
       return [obj, exe]
     end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -560,7 +560,7 @@ module Haconiwa
 
     def do_chroot(base)
       if base.filesystem.chroot
-        Dir.chdir File.expand_path([base.filesystem.chroot, base.workdir].join('/'))
+        Dir.chdir ExpandPath.expand([base.filesystem.chroot, base.workdir].join('/'))
         Dir.chroot base.filesystem.chroot
       else
         Dir.chdir base.workdir

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -96,10 +96,15 @@ module Haconiwa
             ::Procutil.setsid if base.daemon?
 
             apply_namespace(base.namespace)
+            Logger.debug("OK: apply_namespace")
             apply_filesystem(base)
+            Logger.debug("OK: apply_filesystem")
             apply_rlimit(base.resource)
+            Logger.debug("OK: apply_rlimit")
             apply_cgroup(base)
+            Logger.debug("OK: apply_cgroup")
             apply_remount(base)
+            Logger.debug("OK: apply_remount")
             ::Procutil.sethostname(base.name) if base.namespace.flag?(::Namespace::CLONE_NEWUTS)
 
             apply_user_namespace(base.namespace)
@@ -112,19 +117,25 @@ module Haconiwa
               r2.close
               switch_current_namespace_root
             end
+            Logger.debug("OK: apply_user_namespace")
 
             invoke_general_hook(:before_chroot, base)
 
             do_chroot(base)
+            Logger.debug("OK: do_chroot")
             invoke_general_hook(:after_chroot, base)
 
             reopen_fds(base.command) if base.daemon?
 
             apply_capability(base.capabilities)
+            Logger.debug("OK: apply_capability")
             apply_seccomp(base.seccomp)
+            Logger.debug("OK: apply_seccomp")
             switch_guid(base.guid)
+            Logger.debug("OK: switch_guid")
             kick_ok.puts "done"
             kick_ok.close
+            Logger.debug("OK: kick parent process to resume")
 
             Logger.info "Container is going to exec: #{base.init_command.inspect}"
             Exec.execve(base.environ, *base.init_command)
@@ -230,12 +241,12 @@ module Haconiwa
 
     def reload(name, new_cg, new_cg2, new_resource, targets)
       if targets.include?(:cgroup)
-        Haconiwa::Logger.info "Reloading... :cgroup"
+        Logger.info "Reloading... :cgroup"
         reapply_cgroup(name, new_cg, new_cg2)
       end
 
       if targets.include?(:resource)
-        Haconiwa::Logger.info "Reloading... :resource"
+        Logger.info "Reloading... :resource"
         reapply_rlimit(@base.pid, new_resource)
       end
 
@@ -397,6 +408,7 @@ module Haconiwa
       Mount.make_private "/"
       owner_options = base.rootfs.to_owner_options
       base.filesystem.mount_points.each do |mp|
+        Logger.debug("Mounting: #{mp.inspect}")
         case
         when mp.fs
           Mount.mount mp.normalized_src(cwd), mp.dest, owner_options.merge(mp.options).merge(type: mp.fs)
@@ -405,6 +417,7 @@ module Haconiwa
         end
       end
       base.network_mountpoint.each do |mp|
+        Logger.debug("Mounting: #{mp.inspect}")
         unless File.exist? mp.dest
           File.open(mp.dest, "w+") {|f| f.print "" }
         end
@@ -470,8 +483,8 @@ module Haconiwa
         cg.commit
       end
     rescue Exception => e
-      Haconiwa::Logger.warning "Reapply failed: #{e.class}, #{e.message}"
-      e.backtrace.each{|l| Haconiwa::Logger.warning "    #{l}" }
+      Logger.warning "Reapply failed: #{e.class}, #{e.message}"
+      e.backtrace.each{|l| Logger.warning "    #{l}" }
     end
 
     def cleanup_cgroup(base)
@@ -491,12 +504,10 @@ module Haconiwa
         (0..38).each do |cap|
           break unless ::Capability.supported? cap
           next if ids.include?(cap)
-          Logger.debug "Dropping cap of #{cap}"
           ::Capability.drop_bound cap
         end
       else
         capabilities.blacklist_ids.each do |cap|
-          Logger.debug "Dropping cap of #{cap}"
           ::Capability.drop_bound cap
         end
       end
@@ -608,7 +619,7 @@ module Haconiwa
         else
           begin
             File.unlink(pid_file)
-            Haconiwa::Logger.debug("Since the process does not exist, delete the PID file #{pid_file}")
+            Logger.debug("Since the process does not exist, delete the PID file #{pid_file}")
           rescue
             raise "Failed to delete PID file #{pid_file}."
           end

--- a/mrblib/vendor/expand_path.rb
+++ b/mrblib/vendor/expand_path.rb
@@ -1,0 +1,88 @@
+module ExpandPath
+  # Code from mruby-io (https://github.com/iij/mruby-io/blob/master/mrblib/file.rb#L63)
+  # But avoids the nested method def.
+
+  def self.expand_path(path, default_dir = '.')
+    expanded_path = concat_path(path, default_dir)
+    drive_prefix = ""
+    if File::ALT_SEPARATOR && expanded_path.size > 2 &&
+        ("A".."Z").include?(expanded_path[0].upcase) && expanded_path[1] == ":"
+      drive_prefix = expanded_path[0, 2]
+      expanded_path = expanded_path[2, expanded_path.size]
+    end
+    expand_path_array = []
+    if File::ALT_SEPARATOR && expanded_path.include?(File::ALT_SEPARATOR)
+      expanded_path.gsub!(File::ALT_SEPARATOR, '/')
+    end
+    while expanded_path.include?('//')
+      expanded_path = expanded_path.gsub('//', '/')
+    end
+
+    if expanded_path != "/"
+      expanded_path.split('/').each do |path_token|
+        if path_token == '..'
+          if expand_path_array.size > 1
+            expand_path_array.pop
+          end
+        elsif path_token == '.'
+          # nothing to do.
+        else
+          expand_path_array << path_token
+        end
+      end
+
+      expanded_path = expand_path_array.join("/")
+      if expanded_path.empty?
+        expanded_path = '/'
+      end
+    end
+    if drive_prefix.empty?
+      expanded_path
+    else
+      drive_prefix + expanded_path.gsub("/", File::ALT_SEPARATOR)
+    end
+  end
+
+  class << self
+    alias expand expand_path
+  end
+
+  private
+  def self.concat_path(path, base_path)
+    if path[0] == "/" || path[1] == ':' # Windows root!
+      expanded_path = path
+    elsif path[0] == "~"
+      if (path[1] == "/" || path[1] == nil)
+        dir = path[1, path.size]
+        home_dir = _gethome
+
+        unless home_dir
+          raise ArgumentError, "couldn't find HOME environment -- expanding '~'"
+        end
+
+        expanded_path = home_dir
+        expanded_path += dir if dir
+        expanded_path += "/"
+      else
+        splitted_path = path.split("/")
+        user = splitted_path[0][1, splitted_path[0].size]
+        dir = "/" + splitted_path[1, splitted_path.size].join("/")
+
+        home_dir = _gethome(user)
+
+        unless home_dir
+          raise ArgumentError, "user \#{user} doesn't exist"
+        end
+
+        expanded_path = home_dir
+        expanded_path += dir if dir
+        expanded_path += "/"
+      end
+    else
+      expanded_path = concat_path(base_path, _getwd)
+      expanded_path += "/" + path
+    end
+
+    expanded_path
+  end
+end

--- a/mrblib/vendor/expand_path.rb
+++ b/mrblib/vendor/expand_path.rb
@@ -54,7 +54,7 @@ module ExpandPath
     elsif path[0] == "~"
       if (path[1] == "/" || path[1] == nil)
         dir = path[1, path.size]
-        home_dir = _gethome
+        home_dir = File._gethome
 
         unless home_dir
           raise ArgumentError, "couldn't find HOME environment -- expanding '~'"
@@ -68,7 +68,7 @@ module ExpandPath
         user = splitted_path[0][1, splitted_path[0].size]
         dir = "/" + splitted_path[1, splitted_path.size].join("/")
 
-        home_dir = _gethome(user)
+        home_dir = File._gethome(user)
 
         unless home_dir
           raise ArgumentError, "user \#{user} doesn't exist"
@@ -79,7 +79,7 @@ module ExpandPath
         expanded_path += "/"
       end
     else
-      expanded_path = concat_path(base_path, _getwd)
+      expanded_path = concat_path(base_path, File._getwd)
       expanded_path += "/" + path
     end
 


### PR DESCRIPTION
Current `File.expand_path` implementation in mruby (IOW nested methode definition in mruby) seems to be behaving suspiciously. Especially, segfaults on GC occurred around these function calls.

So I just rewrite the implementation using a naive private method.

(And added some log refinements)