### PR TITLE
Support usage of lxcfs in haconiwa container

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -813,6 +813,11 @@ module Haconiwa
       params = FS_TO_MOUNT[fs]
       raise("Unsupported: #{fs}") unless params
 
+      if self.independent_mount_points.map{|mp| mp.to }.include?(params[2])
+        # Skip duplicated mount declaration
+        return
+      end
+
       self.independent_mount_points << MountPoint.new(params[1], to: params[2], fs: params[0])
     end
   end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -813,7 +813,7 @@ module Haconiwa
       params = FS_TO_MOUNT[fs]
       raise("Unsupported: #{fs}") unless params
 
-      if self.independent_mount_points.map{|mp| mp.to }.include?(params[2])
+      if self.independent_mount_points.map{|mp| mp.dest }.include?(params[2])
         # Skip duplicated mount declaration
         return
       end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -18,6 +18,7 @@ module Haconiwa
                   :async_hooks,
                   :wait_interval,
                   :environ,
+                  :lxcfs_root,
                   :attached_capabilities,
                   :signal_handler,
                   :pid,
@@ -71,6 +72,7 @@ module Haconiwa
       @async_hooks = []
       @wait_interval = 50
       @environ = {}
+      @lxcfs_root = nil
       @signal_handler = SignalHandler.new
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
@@ -192,6 +194,11 @@ module Haconiwa
       from = options[:host_root] || '/etc'
       self.network_mountpoint << MountPoint.new("#{from}/resolv.conf", to: "#{root}/etc/resolv.conf")
       self.network_mountpoint << MountPoint.new("#{from}/hosts",       to: "#{root}/etc/hosts")
+    end
+
+    def lxcfs_root=(lxcfs_root)
+      self.mount_independent "procfs" # implicit mount
+      @lxcfs_root = lxcfs_root
     end
 
     def add_general_hook(hookpoint, &b)
@@ -341,6 +348,7 @@ module Haconiwa
         :@async_hooks,
         :@wait_interval,
         :@environ,
+        :@lxcfs_root,
         :@signal_handler,
         :@attached_capabilities,
         :@name,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -578,6 +578,19 @@ module Haconiwa
         opts = ["tmpfs", "devpts"].include?(mp.fs) ? {type: mp.fs}.merge(owner_options) : {type: mp.fs}
         Mount.mount mp.src, "#{base.filesystem.chroot}#{mp.dest}",opts
       end
+
+      if base.lxcfs_root
+        %w(
+          /proc/cpuinfo
+          /proc/diskstats
+          /proc/meminfo
+          /proc/stat
+          /proc/swaps
+          /proc/uptime
+        ).each do |procfile|
+          Mount.bind_mount "#{base.lxcfs_root}#{procfile}", "#{base.filesystem.chroot}#{procfile}", readonly: true
+        end
+      end
     end
 
     def reopen_fds(command)


### PR DESCRIPTION
We now can mock /proc/cpuinfo, /proc/meminfo... to container's environment, not hosts one.