### PR TITLE
Enable basis of netowrking config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.cgroup` - Assign cgroup parameters via `[]=`
 * `config.namespace.unshare` - Unshare the namespaces like `"mount"`, `"ipc"` or `"pid" ...`. `persist_in` option make the specified namespace persist in a bind-moounted-file
   * See: http://karelzak.blogspot.jp/2015/04/persistent-namespaces.html
+* `config.network` - Specify networking config. `Network#namespace` and `#container_ip` must be set. Other attributes are `#bridge_name`, `#bridge_ip`, `#veth_host`, `#veth_guest`
 * `config.capabilities.reset_to_privileged!` - Haconiwa has default capability whitelist to use. If you want to use customized black/whitelist, declare this first
 * `config.capabilities.allow` - Allow capabilities on container root. Setting parameters other than `:all` should make this acts as whitelist
 * `config.capabilities.drop` - Drop capabilities of container root. Default to act as blacklist
@@ -162,6 +163,7 @@ And `attach` is not concerned with capabilities which is granted to container. S
 * `config.support_reload` - Specify reloadable parameters when invoked `haconiwa reload` command. Only `:cgroup` and `:resource` are available for now and it is active only when they are defined following configuration blocks. See test cases and examples
 * `config.wait_interval` - Specify the sleep interval in `wait` and `watchdog` loops by milli seconds
 * `config.metadata` - Add container's metadata(tagging) by ruby Hash
+* `config.lxcfs_root` - Set your host's `lxcfs` mount point to cooperate with containers
 
 You can pick your own parameters for your use case of container.
 e.g. just using `mount` namespace unshared, container with common filesystem, limit the cgroups for big resource job and so on.

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -831,14 +831,24 @@ module Haconiwa
   class Network
     def initialize
       @bridge_name = 'haconiwa0'
-      @bridge_ip, @netmask = `ip -f inet -o addr show #{@bridge_name}`.split[3].split('/')
+      @bridge_ip, @netmask = detect_bridge_ip_mask
     end
     attr_accessor :container_ip,
                   :bridge_name,
                   :bridge_ip,
                   :netmask,
                   :namespace
-    attr_writer :veth_host, :veth_guest
+    attr_writer   :veth_host,
+                  :veth_guest
+
+    def enabled?
+      !!(container_ip)
+    end
+
+    def bridge_name=(newname)
+      @bridge_name = newname
+      @bridge_ip, @netmask = detect_bridge_ip_mask
+    end
 
     def veth_host
       @veth_host ||= ::SHA1.sha1_hex(self.namespace)[0, 8] + '_h'
@@ -846,6 +856,11 @@ module Haconiwa
 
     def veth_guest
       @veth_guest ||= ::SHA1.sha1_hex(self.namespace)[0, 8] + '_g'
+    end
+
+    private
+    def detect_bridge_ip_mask
+      `ip -f inet -o addr show #{@bridge_name}`.split[3].split('/')
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -836,7 +836,17 @@ module Haconiwa
     attr_accessor :container_ip,
                   :bridge_name,
                   :bridge_ip,
-                  :netmask
+                  :netmask,
+                  :namespace
+    attr_writer :veth_host, :veth_guest
+
+    def veth_host
+      @veth_host ||= ::SHA1.sha1_hex(self.namespace)[0, 8] + '_h'
+    end
+
+    def veth_guest
+      @veth_guest ||= ::SHA1.sha1_hex(self.namespace)[0, 8] + '_g'
+    end
   end
 
   class MountPoint

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -829,12 +829,7 @@ module Haconiwa
   end
 
   class Network
-    def initialize
-      @bridge_name = 'haconiwa0'
-      @bridge_ip, @netmask = detect_bridge_ip_mask
-    end
     attr_accessor :container_ip,
-                  :bridge_name,
                   :bridge_ip,
                   :netmask,
                   :namespace
@@ -845,9 +840,17 @@ module Haconiwa
       !!(container_ip)
     end
 
+    def bridge_name
+      @bridge_name ||= begin
+                         @bridge_ip, @netmask = detect_bridge_ip_mask('haconiwa0')
+                         'haconiwa0'
+                       end
+    end
+
     def bridge_name=(newname)
       @bridge_name = newname
       @bridge_ip, @netmask = detect_bridge_ip_mask
+      @bridge_name
     end
 
     def veth_host
@@ -859,8 +862,8 @@ module Haconiwa
     end
 
     private
-    def detect_bridge_ip_mask
-      `ip -f inet -o addr show #{@bridge_name}`.split[3].split('/')
+    def detect_bridge_ip_mask(brname=@bridge_name)
+      `ip -f inet -o addr show #{brname}`.split[3].split('/')
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -7,6 +7,7 @@ module Haconiwa
                   :workdir,
                   :command,
                   :filesystem,
+                  :network,
                   :resource,
                   :cgroup,
                   :cgroupv2,
@@ -61,6 +62,7 @@ module Haconiwa
       @workdir = "/"
       @command = Command.new
       @filesystem = Filesystem.new
+      @network = Network.new
       @resource = Resource.new
       @cgroup = CGroup.new
       @cgroupv2 = CGroupV2.new
@@ -340,6 +342,7 @@ module Haconiwa
         :@workdir,
         :@command,
         :@filesystem,
+        :@network,
         :@resource,
         :@cgroup,
         :@cgroupv2,
@@ -823,6 +826,17 @@ module Haconiwa
 
       self.independent_mount_points << MountPoint.new(params[1], to: params[2], fs: params[0])
     end
+  end
+
+  class Network
+    def initialize
+      @bridge_name = 'haconiwa0'
+      @bridge_ip, @netmask = `ip -f inet -o addr show #{@bridge_name}`.split[3].split('/')
+    end
+    attr_accessor :container_ip,
+                  :bridge_name,
+                  :bridge_ip,
+                  :netmask
   end
 
   class MountPoint

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -5,6 +5,9 @@ module Haconiwa
         o.string('n', 'name', 'CONTAINER_NAME', "Specify the container name if you want")
         o.string('r', 'root', 'ROOTFS_LOC', "Specify the rootfs location to generate on host")
         o.literal('G', 'global', "Create global config /etc/haconiwa.conf.rb")
+        o.literal('N', 'bridge', "Create haconiwa's network bridge")
+        o.string('B', 'bridge-name', 'HACONIWA0', "Specify the bridge's name. default to `haconiwa0'")
+        o.string('I', 'bridge-ip', '10.0.0.1/24', "Specify the bridge's IP and netmask")
       end
 
       haconame = opt['n'].exist? ? opt['n'].value : nil
@@ -12,6 +15,10 @@ module Haconiwa
 
       if opt['G'].exist?
         Haconiwa::Generator.generate_global_config
+      elsif opt['N'].exist?
+        brname = opt['B'].exist? ? opt['B'].value : 'haconiwa0'
+        brip   = opt['I'].exist? ? opt['I'].value : '10.0.0.1/24'
+        NetworkHandler::Bridge.generate_bridge(brname, brip)
       else
         Haconiwa::Generator.generate_hacofile(opt.catchall.value(0), haconame, root)
       end

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -1,7 +1,7 @@
 module Haconiwa
   module Cli
     def self.init(args)
-      opt = parse_opts(args, 'HACO_FILE', ignore_catchall: lambda {|o| o['G'].exist? } ) do |o|
+      opt = parse_opts(args, 'HACO_FILE', ignore_catchall: lambda {|o| o['G'].exist? || o['N'].exist? } ) do |o|
         o.string('n', 'name', 'CONTAINER_NAME', "Specify the container name if you want")
         o.string('r', 'root', 'ROOTFS_LOC', "Specify the rootfs location to generate on host")
         o.literal('G', 'global', "Create global config /etc/haconiwa.conf.rb")

--- a/mrblib/haconiwa/network_handler.rb
+++ b/mrblib/haconiwa/network_handler.rb
@@ -36,7 +36,7 @@ class NetworkHandler
       [
         "ip link add #{network.veth_host} type veth peer name #{network.veth_guest}",
         "ip link set #{network.veth_host} up",
-        "ip link set dev #{network.veth_host} master #{netwotk.bridge_name}"
+        "ip link set dev #{network.veth_host} master #{network.bridge_name}"
       ].each do |cmd|
         unless system(cmd)
           raise "Creating veth failed: #{cmd}"

--- a/mrblib/haconiwa/network_handler.rb
+++ b/mrblib/haconiwa/network_handler.rb
@@ -1,0 +1,61 @@
+class NetworkHandler
+  class Bridge
+    def initialize(network)
+      @network = network
+      if !network.namespace || !network.container_ip
+        raise ArgumentError, "Required network config(s) are missing: #{network.inspect}"
+      end
+    end
+    attr_reader :network
+
+    def to_ns_file
+      "/var/run/netns/#{network.namespace}"
+    end
+
+    def generate
+      make_network_namespace
+      make_veth
+      make_container_network
+    end
+
+    def cleanup
+      unless system("ip netns del #{network.namespace}")
+        raise "Cleanup of namespace failed"
+      end
+      system "ip link del #{network.veth_host} || true"
+    end
+
+    private
+    def make_network_namespace
+      unless system("ip netns add #{network.namespace}")
+        raise "Creating namespace failed"
+      end
+    end
+
+    def make_veth
+      [
+        "ip link add #{network.veth_host} type veth peer name #{network.veth_guest}",
+        "ip link set #{network.veth_host} up",
+        "ip link set dev #{network.veth_host} master #{netwotk.bridge_name}"
+      ].each do |cmd|
+        unless system(cmd)
+          raise "Creating veth failed: #{cmd}"
+        end
+      end
+    end
+
+    def make_container_network
+      ns = network.namespace
+      [
+        "ip link set #{network.veth_guest} netns #{ns} up",
+        "ip netns exec #{ns} ip addr add #{network.container_ip}/#{network.netmask} dev #{network.veth_guest}",
+        "ip netns exec #{ns} ip link set lo up",
+        "ip netns exec #{ns} ip route add default via #{network.bridge_ip}"
+      ].each do |cmd|
+        unless system(cmd)
+          raise "Creating container networks failed: #{cmd}"
+        end
+      end
+    end
+  end
+end

--- a/mrblib/haconiwa/network_handler.rb
+++ b/mrblib/haconiwa/network_handler.rb
@@ -57,5 +57,22 @@ class NetworkHandler
         end
       end
     end
+
+    def self.generate_bridge(bridge_name, bridge_ip_netmask)
+      unless bridge_ip_netmask =~ /\/\d+$/
+        bridge_ip_netmask << '/24'
+      end
+      runner = RunCmd.new("init.network.bridge")
+      [
+        "ip link add #{bridge_name} type bridge",
+        "ip addr add #{bridge_ip_netmask} dev #{bridge_name}",
+        "ip link set dev #{bridge_name} up"
+      ].each do |cmd|
+        _, status = runner.run(cmd)
+        if !status.success?
+          raise "Creating container networks failed: #{cmd}"
+        end
+      end
+    end
   end
 end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -238,6 +238,10 @@ module Haconiwa
         ::Namespace.setns(::Namespace::CLONE_NEWPID, pid: base.pid)
       end
       pid = Process.fork do
+        if base.network.enabled?
+          nw_handler = NetworkHandler::Bridge.new(base.network)
+          base.namespace.enter "net", via: nw_handler.to_ns_file
+        end
         flag = base.namespace.to_flag_without_pid_and_user
         ::Namespace.setns(flag, pid: base.pid)
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -61,6 +61,8 @@ module Haconiwa
     end
 
     def run(options, init_command)
+      GC.disable # FIXME: temp, thread GC problem
+
       begin
         pid_file = Pidfile.create(@base.container_pid_file)
       rescue => e

--- a/sample/network.haco
+++ b/sample/network.haco
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+haconiwa = Haconiwa.define do |config|
+  config.name = "haconiwa-nw-test#{ENV['SUFFIX']}" # to be hostname
+  config.init_command = ["/usr/sbin/sshd", '-D']
+  config.daemonize!
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.chroot_to root
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  config.network.namespace = config.name
+  config.network.container_ip = '10.254.254.10'
+  config.network.bridge_name = 'hogehoge0'
+
+  # sshd needs chroot!
+  config.capabilities.allow "cap_sys_chroot"
+  config.capabilities.allow "cap_kill"
+end


### PR DESCRIPTION
See sample.

## Add bridge generator

```console
$ sudo haconiwa init --bridge --bridge-name=haconiwa0 --bridge-ip=10.127.127.1/24
```

## Add network DSL

```ruby
Haconiwa.define do |config|
  config.network.namespace = config.name
  config.network.container_ip = '10.127.127.10'
  config.network.bridge_name = 'haconiwa0'
  #...
end
```