### PR TITLE
Version to 1.0.0.alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
 branches:
   only:
     - master
+    - checkpoint
 cache:
   directories:
     - mruby

--- a/mrblib/haconiwa/version.rb
+++ b/mrblib/haconiwa/version.rb
@@ -1,3 +1,3 @@
 module Haconiwa
-  VERSION = "0.9.1"
+  VERSION = "1.0.0.alpha"
 end


### PR DESCRIPTION
After checkpoint-restore support, Haconiwa will be verison 1.0.0