### PR TITLE
Basic implementation of cgroup hook: memory_pressure

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -36,6 +36,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-cgroupv2'  , :github => 'haconiwa/mruby-cgroupv2'
   spec.add_dependency 'mruby-lockfile', :github => 'udzura/mruby-lockfile'
   spec.add_dependency 'mruby-fibered_worker' , :github => 'udzura/mruby-fibered_worker'
+  spec.add_dependency 'mruby-eventfd' , :github => 'matsumotory/mruby-eventfd'
 
   spec.add_dependency 'mruby-syslog'    , :github => 'udzura/mruby-syslog'
   spec.add_dependency 'mruby-sha1', :github => 'mattn/mruby-sha1'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -17,6 +17,7 @@ module Haconiwa
                   :seccomp,
                   :general_hooks,
                   :async_hooks,
+                  :cgroup_hooks,
                   :wait_interval,
                   :environ,
                   :lxcfs_root,
@@ -72,6 +73,7 @@ module Haconiwa
       @seccomp = Seccomp.new
       @general_hooks = {}
       @async_hooks = []
+      @cgroup_hooks = []
       @wait_interval = 5
       @environ = {}
       @lxcfs_root = nil
@@ -221,6 +223,10 @@ module Haconiwa
     end
     alias after_spawn add_async_hook
 
+    def add_cgroup_hook(options={}, &hook)
+      @cgroup_hooks << WaitLoop::CGroupHook.new(options, &hook)
+    end
+
     def bootstrap
       @bootstrap ||= Bootstrap.new
       yield(@bootstrap) if block_given?
@@ -352,6 +358,7 @@ module Haconiwa
         :@seccomp,
         :@general_hooks,
         :@async_hooks,
+        :@cgroup_hooks,
         :@wait_interval,
         :@environ,
         :@lxcfs_root,

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -9,13 +9,26 @@ module Haconiwa
     def register_hooks(base)
       base.async_hooks.each do |hook|
         hook.set_signal!
-        proc = hook.proc
+        blk = hook.proc
         @mainloop.register_timer(hook.signal, hook.timing, hook.interval) do
           ::Haconiwa::Logger.warning("Async hook starting...")
           begin
-            proc.call(base)
+            blk.call(base)
           rescue => e
             ::Haconiwa::Logger.warning("Async hook failed: #{e.class}, #{e.message}")
+          end
+        end
+      end
+
+      base.cgroup_hooks.each do |cghook|
+        cghook.register!(base)
+        blk = cghook.proc
+        @mainloop.register_fd(cghook.fileno) do |_dummy|
+          ::Haconiwa::Logger.warning("Cgroup hook[#{cghook.type}] starting...")
+          begin
+            blk.call(base)
+          rescue => e
+            ::Haconiwa::Logger.warning("Async hook[#{cghook.type}] failed: #{e.class}, #{e.message}")
           end
         end
       end
@@ -116,21 +129,20 @@ module Haconiwa
     class CGroupHook
       VALID_TYPES = %w(memory_pressure oom).freeze
 
-      def initialize(base, opt={}, &b)
+      def initialize(opt={}, &b)
         @type = opt[:type]
         if VALID_TYPES.include?(@type.to_s)
           raise "Invalid hook type: #{@type}"
         end
         @level = opt[:level] || "critical"
         @proc = b
-        @base = base
       end
-      attr_reader :proc
+      attr_reader :type, :level, :proc
 
-      def register!
+      def register!(base)
         make_eventfd
-        cfd = open_cgroup_file
-        write_to_control(@efd.fd, cfd.fileno)
+        cfd = open_cgroup_file(base)
+        write_to_control(base, @efd.fd, cfd.fileno)
         @efd
       end
 
@@ -144,12 +156,12 @@ module Haconiwa
         @efd = ::Eventfd.new(0, 0) # TODO: define Eventfd::EFD_NONBLOCK
       end
 
-      def open_cgroup_file
-        File.open("/sys/fs/cgroup/memory/#{@base.name}/memory.pressure_level")
+      def open_cgroup_file(base)
+        File.open("/sys/fs/cgroup/memory/#{base.name}/memory.pressure_level")
       end
 
-      def write_to_control(efd, cfd)
-        f = File.open("/sys/fs/cgroup/memory/#{@base.name}/cgroup.event_control")
+      def write_to_control(base, efd, cfd)
+        f = File.open("/sys/fs/cgroup/memory/#{base.name}/cgroup.event_control")
         f.write "#{efd} #{cfd} #{@level}"
         f.close
       end

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -131,7 +131,7 @@ module Haconiwa
 
       def initialize(opt={}, &b)
         @type = opt[:type]
-        if VALID_TYPES.include?(@type.to_s)
+        unless VALID_TYPES.include?(@type.to_s)
           raise "Invalid hook type: #{@type}"
         end
         @level = opt[:level] || "critical"
@@ -157,11 +157,11 @@ module Haconiwa
       end
 
       def open_cgroup_file(base)
-        File.open("/sys/fs/cgroup/memory/#{base.name}/memory.pressure_level")
+        File.open("/sys/fs/cgroup/memory/#{base.name}/memory.pressure_level", "r")
       end
 
       def write_to_control(base, efd, cfd)
-        f = File.open("/sys/fs/cgroup/memory/#{base.name}/cgroup.event_control")
+        f = File.open("/sys/fs/cgroup/memory/#{base.name}/cgroup.event_control", "w")
         f.write "#{efd} #{cfd} #{@level}"
         f.close
       end

--- a/sample/cgroup_event.haco
+++ b/sample/cgroup_event.haco
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+level = ENV['PRESSURE_LEVEL'] || "medium"
+
+haconiwa = Haconiwa.define do |config|
+  config.name = "cgroup-event-test" # to be hostname
+  config.init_command = ["/usr/bin/ruby", "-e", "GC.disable; loop { ha = Hash.new; (1..10000).each {|i| ha[i.to_s] = rand(65535).to_s; sleep 0.0001 } }"]
+  config.daemonize!
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_network_etc(root, host_root: "/etc")
+  config.chroot_to root
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  config.cgroup["memory.limit_in_bytes"] = 16 * 1024 * 1024 # 50MB...
+
+  Haconiwa::Logger.puts "Memory pressure level: #{level}"
+  config.add_cgroup_hook type: "memory_pressure", level: level do |base|
+    Haconiwa::Logger.puts "[#{base.pid}] Memory pressure now!"
+    system "ps auxf | grep -e RSS -e GC.disable"
+    ::Process.kill :TERM, base.pid
+  end
+end

--- a/sample/cgroup_event.haco
+++ b/sample/cgroup_event.haco
@@ -19,7 +19,7 @@ haconiwa = Haconiwa.define do |config|
   config.namespace.unshare "uts"
   config.namespace.unshare "pid"
 
-  config.cgroup["memory.limit_in_bytes"] = 16 * 1024 * 1024 # 50MB...
+  config.cgroup["memory.limit_in_bytes"] = 16 * 1024 * 1024 # Please change here :)
 
   Haconiwa::Logger.puts "Memory pressure level: #{level}"
   config.add_cgroup_hook type: "memory_pressure", level: level do |base|


### PR DESCRIPTION
Now wa can use this kind of hooks:

```ruby
haconiwa = Haconiwa.define do |config|
  config.cgroup["memory.limit_in_bytes"] = 16 * 1024 * 1024
  config.add_cgroup_hook type: "memory_pressure", level: level do |base|
    Haconiwa::Logger.puts "[#{base.pid}] Memory pressure now!"
    system "ps auxf | grep -e RSS -e GC.disable"
    ::Process.kill :TERM, base.pid
  end
end
```

Example run:

```console
$ sudo env PRESSURE_LEVEL=critical ./mruby/bin/haconiwa run sample/cgroup_event.haco -T                           
Memory pressure level: critical
Create lock: #<Lockfile path=/var/lock/.cgroup-event-test.hacolock>
Container fork success and going to wait: pid=6050
Cgroup hook[memory_pressure] starting...
[6050] Memory pressure now!
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root      6050  6.1  1.9  52080 19896 pts/0    Sl+  06:47   0:00  |                       \_ /usr/bin/ruby -e GC.disable; loop { ha = Hash.new; (1..10000).each {|i| ha[i.to_s] = rand(65535).to_s; sleep 0.0001 } }
root      6066  0.0  0.0   4652   772 pts/0    S+   06:47   0:00  |                       \_ sh -c ps auxf | grep -e RSS -e GC.disable                                             
root      6068  0.0  0.1  14856  1064 pts/0    S+   06:47   0:00  |                           \_ grep -e RSS -e GC.disable                                                         
Container[Host PID=6050] finished: #<Process::Status: pid=6050,exited(1)>
Container failed: #<Process::Status: pid=6050,exited(1)>
Remoing pidfile: #<Pidfile:0x55eebb872a90>
Removed pidfile: #<Pidfile:0x55eebb872a90>
One of supervisors finished: 6049, #<Process::Status: pid=6049,exited(0)>
```