### PR TITLE
Add net_bind_service to allowed capabilities

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -568,6 +568,7 @@ module Haconiwa
       cap_dac_override
       cap_fowner
       cap_fsetid
+      cap_net_bind_service
       cap_net_raw
       cap_setgid
       cap_setfcap


### PR DESCRIPTION
I think that it is unnecessary to make it as strict as the web server can not be started with default. Therefore, it gives network capability.