### PR TITLE
Set criu's location as config

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -996,8 +996,10 @@ module Haconiwa
       @images_dir = "/var/run/haconiwa/checkpoint"
       @criu_log_file = "-"
       @criu_service_address = "/var/run/criu_service.socket"
+      @criu_bin_path = "/usr/local/sbin/criu"
     end
-    attr_accessor :target_syscall, :images_dir, :criu_log_file, :criu_service_address
+    attr_accessor :target_syscall, :images_dir,
+                  :criu_log_file, :criu_service_address, :criu_bin_path
 
     def target_syscall(*args)
       if args.size == 0

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -51,7 +51,7 @@ module Haconiwa
       # Hooks won't work
       pidfile = "/tmp/.__criu_restored_#{@base.name}.pid"
       cmds = [
-        "/usr/local/sbin/criu", "restore",
+        checkpoint.criu_bin_path, "restore",
         "--shell-job",
         "--pidfile", pidfile, # FIXME: shouldn't criu cli pass its pid via envvar?
         "-D", checkpoint.images_dir


### PR DESCRIPTION
It is useful to handle crius installed other than `"/usr/local/sbin/criu"`