### PR TITLE
Restore mount namespace / use pivot_root to change rootfs

### DIFF
--- a/bintest/fixtures/hooks-test.haco
+++ b/bintest/fixtures/hooks-test.haco
@@ -65,4 +65,6 @@ apk --no-cache add ruby
       f.puts data
     end
   end
+
+  config.filesystem.use_legacy_chroot = true
 end

--- a/bintest/fixtures/just-sleep.haco.erb
+++ b/bintest/fixtures/just-sleep.haco.erb
@@ -23,4 +23,6 @@ Haconiwa.define do |config|
   config.namespace.unshare "ipc"
   config.namespace.unshare "uts"
   config.namespace.unshare "pid"
+
+  config.filesystem.use_legacy_chroot = true
 end

--- a/bintest/fixtures/reload-test.haco
+++ b/bintest/fixtures/reload-test.haco
@@ -48,4 +48,6 @@ apk --no-cache add ruby
   end
 
   config.support_reload :cgroup, :resource
+
+  config.filesystem.use_legacy_chroot = true
 end

--- a/bintest/walkthrough.rb
+++ b/bintest/walkthrough.rb
@@ -57,6 +57,9 @@ assert('walkthrough') do
     system %Q(sed -i 's!b.os_type.*!b.git_url = "https://github.com/haconiwa/haconiwa-image-alpine"!' #{haconame})
     system %Q(sed -i 's!apk add.*!apk update\\napk upgrade\\napk --no-cache add ruby!' #{haconame})
 
+    # use legacy chroot for test...
+    system %Q(sed -i '6a config.filesystem.use_legacy_chroot = true' #{haconame})
+
     output, status = run_haconiwa "create", haconame
     assert_true status.success?, "Process did not exit cleanly: create"
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -892,10 +892,12 @@ module Haconiwa
       @mount_points = []
       @independent_mount_points = []
       @rootfs = Rootfs.new(nil)
+      @use_legacy_chroot = false
     end
     attr_accessor :mount_points,
                   :independent_mount_points,
-                  :rootfs
+                  :rootfs,
+                  :use_legacy_chroot
 
     FS_TO_MOUNT = {
       "procfs" => ["proc", "proc", "/proc"],
@@ -912,6 +914,7 @@ module Haconiwa
     def chroot
       self.rootfs.root
     end
+    alias root_path chroot
 
     def mount_independent(fs)
       params = FS_TO_MOUNT[fs]

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -783,7 +783,9 @@ module Haconiwa
     def to_bit(ns)
       case ns
       when String, Symbol
-        NS_MAPPINGS[ns.to_s]
+        bin = NS_MAPPINGS[ns.to_s]
+        raise(ArgumentError, "Invalid namespace name #{ns.inspect}") unless bin
+        bin
       when Integer
         ns
       end

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -68,7 +68,12 @@ module Haconiwa
         ENV['HACONIWA_RUN_AS_CRIU_ACTION_SCRIPT'] = "true"
       end
 
-      cmds.concat(["--exec-cmd", "--", self_exe, "_restored", @base.hacofile, pidfile])
+      cmds.concat(
+        [
+          "--root", @base.filesystem.root_path,
+          "--exec-cmd",
+          "--", self_exe, "_restored", @base.hacofile, pidfile
+        ])
       Haconiwa::Logger.debug("Going to exec: #{cmds.inspect}")
       ::Exec.execve(ENV, *cmds)
     end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -443,7 +443,8 @@ module Haconiwa
       end
 
       if namespace.flag?(::Namespace::CLONE_NEWNS)
-        Mount.make_private "/"
+        # Mount.make_private "/"
+        Mount.__mount__("none", "/", nil, (Mount::MS_REC | Mount::MS_PRIVATE), nil)
       end
     end
 
@@ -479,6 +480,8 @@ module Haconiwa
     def apply_filesystem(base)
       unless base.filesystem.use_legacy_chroot
         Mount.bind_mount base.filesystem.root_path, base.filesystem.root_path
+        #Mount.make_private base.filesystem.root_path
+        Mount.__mount__("none", base.filesystem.root_path, nil, (Mount::MS_REC | Mount::MS_PRIVATE), nil)
       end
 
       return if base.filesystem.no_special_config? && base.network_mountpoint.empty?

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -479,6 +479,10 @@ module Haconiwa
     def apply_filesystem(base)
       return if base.filesystem.no_special_config? && base.network_mountpoint.empty?
 
+      unless base.filesystem.use_legacy_chroot
+        Mount.bind_mount base.filesystem.root_path, base.filesystem.root_path
+      end
+
       cwd = Dir.pwd
       owner_options = base.rootfs.to_owner_options
       base.filesystem.mount_points.each do |mp|

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -27,7 +27,7 @@ module Haconiwa
         @mainloop.register_handler(sig, true) do
           unless base.cleaned
             ::Haconiwa::Logger.warning "Supervisor received unintended kill. Cleanup..."
-            runner.cleanup_supervisor(base)
+            runner.run_cleanups_after_exit(::Process::Status.new(base.pid, 127))
           end
           Process.kill :TERM, base.pid
           exit 127

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -64,8 +64,12 @@ Haconiwa.define do |config|
     end
   end
 
+  config.mount_independent "procfs"
+  config.mount_independent "devtmpfs"
+
+  config.namespace.unshare "mount"
   config.namespace.unshare "uts"
   config.namespace.unshare "ipc"
-  config.namespace.unshare "pid"
+  config.namespace.unshare "pid" # also network is unshared
   config.capabilities.reset_to_privileged!
 end

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -46,11 +46,11 @@ Haconiwa.define do |config|
       c.set_shell_job true
       begin
         c.set_pid base.pid
-        c.dump
+        # c.dump
       rescue => e
         Haconiwa::Logger.puts "CRIU[hook]: dump failed: #{e.class}, #{e.message}"
       else
-        Haconiwa::Logger.puts "CRIU[hook]: dumped!!"
+        Haconiwa::Logger.puts "CRIU[hook]: dump skipped!!"
       end
     end
   else
@@ -72,4 +72,8 @@ Haconiwa.define do |config|
   config.namespace.unshare "ipc"
   config.namespace.unshare "pid" # also network is unshared
   config.capabilities.reset_to_privileged!
+
+  if ENV['USE_LEGACY_CHROOT']
+    config.filesystem.use_legacy_chroot = true
+  end
 end

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -67,6 +67,9 @@ Haconiwa.define do |config|
 
   config.mount_independent "procfs"
   config.mount_independent "devtmpfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
 
   config.namespace.unshare "mount"
   config.namespace.unshare "uts"

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -3,7 +3,8 @@ suffix = ENV['SUFFIX']
 Haconiwa.define do |config|
   config.name = "chroot-rails001-#{suffix}" # to be hostname
   config.init_command = %w(/u/app/helloworld/bin/rails server)
-  config.acts_as_session_leader
+  #config.acts_as_session_leader
+  config.daemonize!
 
   root = Pathname.new("/var/lib/haconiwa/rails-sample")
   config.chroot_to root
@@ -46,7 +47,7 @@ Haconiwa.define do |config|
       c.set_shell_job true
       begin
         c.set_pid base.pid
-        # c.dump
+        c.dump
       rescue => e
         Haconiwa::Logger.puts "CRIU[hook]: dump failed: #{e.class}, #{e.message}"
       else

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -48,10 +48,6 @@ static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "z", &newroot);
 
-  oldrootfd = open("/", O_DIRECTORY | O_RDONLY);
-  if (oldrootfd < 0) {
-    mrb_sys_fail(mrb, "open(/)");
-  }
   newrootfd = open(newroot, O_DIRECTORY | O_RDONLY);
   if (newrootfd < 0) {
     mrb_sys_fail(mrb, "open(newroot)");
@@ -65,6 +61,10 @@ static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
     mrb_sys_fail(mrb, "Cannot pivot_root!");
   }
 
+  oldrootfd = open("./.gc", O_DIRECTORY | O_RDONLY);
+  if (oldrootfd < 0) {
+    mrb_sys_fail(mrb, "open(oldrootfd)");
+  }
   if (fchdir(oldrootfd) < 0) {
     mrb_sys_fail(mrb, "fchdir(oldroot)");
   }

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -44,7 +44,7 @@ int pivot_root(const char *new_root, const char *put_old){
 static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
 {
   char *newroot;
-  int newrootfd = -1, oldrootfd = -1;
+  int newrootfd = -1;
 
   mrb_get_args(mrb, "z", &newroot);
 
@@ -61,20 +61,12 @@ static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
     mrb_sys_fail(mrb, "Cannot pivot_root!");
   }
 
-  oldrootfd = open("./.gc", O_DIRECTORY | O_RDONLY);
-  if (oldrootfd < 0) {
-    mrb_sys_fail(mrb, "open(oldrootfd)");
+  if (chdir("/") < 0) {
+    mrb_sys_fail(mrb, "chdir(newroot) back");
   }
-  if (fchdir(oldrootfd) < 0) {
-    mrb_sys_fail(mrb, "fchdir(oldroot)");
-  }
-  if (umount2(".", MNT_DETACH) < 0) {
+  if (umount2("/.gc", MNT_DETACH) < 0) {
     mrb_sys_fail(mrb, "umount2");
   }
-  if (fchdir(newrootfd) < 0) {
-    mrb_sys_fail(mrb, "fchdir(newroot) back");
-  }
-  close(oldrootfd);
   close(newrootfd);
 
   return mrb_true_value();

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -1,6 +1,15 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
 #include "mruby.h"
 #include "mruby/string.h"
 #include "mruby/hash.h"
+#include "mruby/error.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
@@ -25,11 +34,57 @@ static mrb_value mrb_haconiwa_mrgbem_revisions(mrb_state *mrb, mrb_value self)
   return ha;
 }
 
+int pivot_root(const char *new_root, const char *put_old){
+  return (int)syscall(SYS_pivot_root, new_root, put_old);
+}
+
+/* TODO: This method will be implemented in mruby-procutil */
+/* This function is written after lxc/conf.c
+   https://github.com/lxc/lxc/blob/a467a845443054a9f75d65cf0a73bb4d5ff2ab71/src/lxc/conf.c */
+static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
+{
+  char *newroot;
+  int newrootfd = -1, oldrootfd = -1;
+
+  mrb_get_args(mrb, "z", &newroot);
+
+  oldrootfd = open("/", O_DIRECTORY | O_RDONLY);
+  if (oldrootfd < 0) {
+    mrb_sys_fail(mrb, "open(/)");
+  }
+  newrootfd = open(newroot, O_DIRECTORY | O_RDONLY);
+  if (newrootfd < 0) {
+    mrb_sys_fail(mrb, "open(newroot)");
+  }
+  if (fchdir(newrootfd) < 0) {
+    mrb_sys_fail(mrb, "fchdir(newroot)");
+  }
+
+  if (pivot_root(".", ".") < 0) {
+    mrb_sys_fail(mrb, "Cannot pivot_root!");
+  }
+
+  if (fchdir(oldrootfd) < 0) {
+    mrb_sys_fail(mrb, "fchdir(oldroot)");
+  }
+  if (umount2(".", MNT_DETACH) < 0) {
+    mrb_sys_fail(mrb, "umount2");
+  }
+  if (fchdir(newrootfd) < 0) {
+    mrb_sys_fail(mrb, "fchdir(newroot) back");
+  }
+  close(oldrootfd);
+  close(newrootfd);
+
+  return mrb_true_value();
+}
+
 void mrb_haconiwa_gem_init(mrb_state *mrb)
 {
   struct RClass *haconiwa;
   haconiwa = mrb_define_module(mrb, "Haconiwa");
   mrb_define_class_method(mrb, haconiwa, "mrbgem_revisions", mrb_haconiwa_mrgbem_revisions, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, haconiwa, "pivot_root_to", mrb_haconiwa_pivot_root_to, MRB_ARGS_REQ(1));
 
   DONE;
 }

--- a/src/haconiwa.c
+++ b/src/haconiwa.c
@@ -60,7 +60,8 @@ static mrb_value mrb_haconiwa_pivot_root_to(mrb_state *mrb, mrb_value self)
     mrb_sys_fail(mrb, "fchdir(newroot)");
   }
 
-  if (pivot_root(".", ".") < 0) {
+  if (pivot_root(".", "./.gc") < 0) {
+    perror("pivot_root");
     mrb_sys_fail(mrb, "Cannot pivot_root!");
   }
 


### PR DESCRIPTION
* Restore mount namespace via CRIU
* Use pivot_root instead of chroot. To force using chroot, write below:

```ruby
config.filesystem.use_legacy_chroot = true
```