### PR TITLE
Support AppArmor

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -25,6 +25,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-process'   , :github => 'iij/mruby-process'
   spec.add_dependency 'mruby-socket'    , :mgem => 'mruby-socket'
   spec.add_dependency 'mruby-seccomp'   , :github => 'chikuwait/mruby-seccomp'
+  spec.add_dependency 'mruby-apparmor'  , :github => 'haconiwa/mruby-apparmor'
 
   spec.add_dependency 'mruby-onig-regexp', :github => 'udzura/mruby-onig-regexp'
   spec.add_dependency 'mruby-argtable'  , :github => 'udzura/mruby-argtable', :branch => 'static-link-argtable3'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -34,6 +34,8 @@ module Haconiwa
                   :reloadable_attr,
                   :exit_status
 
+    alias apparmor_profile= apparmor=
+
     delegate     [:uid,
                   :uid=,
                   :gid,

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -15,6 +15,7 @@ module Haconiwa
                   :capabilities,
                   :guid,
                   :seccomp,
+                  :apparmor,
                   :checkpoint,
                   :general_hooks,
                   :async_hooks,
@@ -71,6 +72,7 @@ module Haconiwa
       @capabilities = Capabilities.new
       @guid = Guid.new
       @seccomp = Seccomp.new
+      @apparmor = nil
       @checkpoint = Checkpoint.new
       @general_hooks = {}
       @async_hooks = []
@@ -415,6 +417,7 @@ module Haconiwa
         :@capabilities,
         :@guid,
         :@seccomp,
+        :@apparmor,
         :@checkpoint,
         :@general_hooks,
         :@async_hooks,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -127,6 +127,9 @@ module Haconiwa
             Logger.debug("OK: do_chroot")
             invoke_general_hook(:after_chroot, base)
 
+            apply_apparmor(base.apparmor)
+            Logger.debug("OK: apply_apparmor")
+
             reopen_fds(base.command) if base.daemon?
 
             apply_capability(base.capabilities)
@@ -603,6 +606,10 @@ module Haconiwa
         seccomp.defblock.call(ctx)
         ctx.load
       end
+    end
+
+    def apply_apparmor(apparmor)
+      AppArmor.change_onexec(apparmor) if apparmor
     end
 
     def apply_rlimit(rlimit)

--- a/sample/apparmor.haco
+++ b/sample/apparmor.haco
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+Haconiwa.define do |config|
+  config.name = "haconiwa-apparmor-test"
+
+  config.bootstrap do |b|
+    b.strategy = "lxc"
+    b.os_type = "ubuntu"
+  end
+
+  config.init_command = ["/bin/bash"]
+
+  root = Pathname.new("/var/lib/haconiwa/8cfccb3d")
+  config.chroot_to root
+
+  config.add_mount_point "tmpfs", to: root.join("tmp"), fs: "tmpfs"
+  config.mount_independent "procfs"
+  config.mount_independent "sysfs"
+  config.mount_independent "devtmpfs"
+  config.mount_independent "devpts"
+  config.mount_independent "shm"
+
+  config.namespace.unshare "mount"
+  config.namespace.unshare "ipc"
+  config.namespace.unshare "uts"
+  config.namespace.unshare "pid"
+
+  # To begin with you need to load a new profile in AppArmor for use with containers:
+  # apparmor_parser /etc/apparmor.d/haconiwa/haconiwa-deny-top-command
+  # In this example, load profile named `haconiwa-deny-top-command`.
+  config.apparmor = "haconiwa-deny-top-command"
+end

--- a/sample/apparmor_profile/haconiwa-deny-top-command
+++ b/sample/apparmor_profile/haconiwa-deny-top-command
@@ -1,0 +1,64 @@
+#include <tunables/global>
+
+profile haconiwa-deny-top-command flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network inet tcp,
+  network inet udp,
+  network inet icmp,
+
+  deny network raw,
+
+  deny network packet,
+
+  file,
+  umount,
+
+  deny /bin/** wl,
+  deny /boot/** wl,
+  deny /dev/** wl,
+  deny /etc/** wl,
+  deny /home/** wl,
+  deny /lib/** wl,
+  deny /lib64/** wl,
+  deny /media/** wl,
+  deny /mnt/** wl,
+  deny /opt/** wl,
+  deny /proc/** wl,
+  deny /root/** wl,
+  deny /sbin/** wl,
+  deny /srv/** wl,
+  deny /tmp/** wl,
+  deny /sys/** wl,
+  deny /usr/** wl,
+
+  audit /** w,
+
+  deny /usr/bin/top mrwklx,
+
+  capability chown,
+  capability dac_override,
+  capability setuid,
+  capability setgid,
+  capability net_bind_service,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/mem rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}


### PR DESCRIPTION
Added restriction by AppArmor profile to haconiwa container.

### example

```bash
$ cat /etc/apparmor.d/haconiwa/haconiwa-deny-top-command
#include <tunables/global>

profile haconiwa-deny-top-command flags=(attach_disconnected,mediate_deleted) {
  #include <abstractions/base>
  file,

  deny /usr/bin/top mrwklx,
  deny @{PROC}/sysrq-trigger rwklx,

}

$ sudo apparmor_parser -r -W /etc/apparmor.d/haconiwa/haconiwa-deny-top-command
$ sudo ./mruby/build/host/bin/haconiwa start ./sample/apparmor.haco
Create lock: #<Lockfile path=/var/lock/.haconiwa-apparmor-test.hacolock>
Container fork success and going to wait: pid=2228
root@haconiwa-apparmor-test:/# top
bash: /usr/bin/top: Permission denied
root@haconiwa-apparmor-test:/# echo c > /proc/sysrq-trigger
bash: /proc/sysrq-trigger: Permission denied
```

Anothor container runtime  (Docker and LXC) is the profile will be applied automatically. 
Do you have plan for default apparmor profile of haconiwa?
