### PR TITLE
Set stdout/stderr file in both host and pivoted root

### DIFF
--- a/sample/criu.haco
+++ b/sample/criu.haco
@@ -3,7 +3,9 @@ Haconiwa.define do |config|
   config.name = "chroot-apache001" # to be hostname
   config.init_command = %w(/usr/local/apache2/bin/httpd -DFOREGROUND -X)
   # config.init_command = %w(/usr/local/bin/httpd-foreground)
-  config.acts_as_session_leader
+  config.daemonize!
+  config.command.set_stdout(file: "/tmp/container-internal.out")
+  config.command.set_stderr(file: "/tmp/container-internal.err")
 
   root = Pathname.new("/var/lib/haconiwa-apache001")
   config.chroot_to root
@@ -26,5 +28,9 @@ Haconiwa.define do |config|
   config.namespace.unshare "uts"
   config.namespace.unshare "ipc"
   config.namespace.unshare "pid"
+  config.namespace.unshare "mount"
+
+  config.mount_independent "procfs"
+  config.mount_independent "devtmpfs"
   config.capabilities.reset_to_privileged!
 end


### PR DESCRIPTION
* To create container's PID=1 stdout/.err logging in the container itself, use `file:`, using path from  container's root
* To create this in the container's host, use `host_file:`.