### PR TITLE
Support external bind mount, which are not auto-detected

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1048,9 +1048,13 @@ module Haconiwa
       @criu_log_file = "-"
       @criu_service_address = "/var/run/criu_service.socket"
       @criu_bin_path = "/usr/local/sbin/criu"
+
+      @extra_criu_options = []
+      @extra_criu_externals = []
     end
     attr_accessor :target_syscall, :images_dir,
-                  :criu_log_file, :criu_service_address, :criu_bin_path
+                  :criu_log_file, :criu_service_address, :criu_bin_path,
+                  :extra_criu_options, :extra_criu_externals
 
     def target_syscall(*args)
       if args.size == 0

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -953,6 +953,10 @@ module Haconiwa
     end
     alias root_path chroot
 
+    def external_mount_points
+      @mount_points.select{|mp| mp.criu_ext_key }
+    end
+
     def mount_independent(fs)
       params = FS_TO_MOUNT[fs]
       raise("Unsupported: #{fs}") unless params

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1015,9 +1015,10 @@ module Haconiwa
       @dest = options.delete(:to)
       @dest = @dest.to_s if @dest
       @fs = options.delete(:fs)
+      @criu_ext_key = options.delete(:criu_ext_key)
       @options = options
     end
-    attr_accessor :src, :dest, :fs, :options
+    attr_accessor :src, :dest, :fs, :criu_ext_key, :options
 
     def normalized_src(cwd="/")
       if @src.start_with?('/')

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -111,6 +111,14 @@ module Haconiwa
       end
 
       cmds.options.concat(["--root", @base.filesystem.root_path])
+
+      unless checkpoint.extra_criu_options.empty?
+        cmds.options.concat(checkpoint.extra_criu_options)
+      end
+      checkpoint.extra_criu_externals.each do |extra|
+        cmds.externals << extra
+      end
+
       cmds.exec_cmd = [self_exe, "_restored", @base.hacofile, pidfile]
 
       Haconiwa::Logger.debug("Going to exec: #{cmds.inspect}")

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -81,9 +81,8 @@ module Haconiwa
       # TODO: embed criu(crtools) to haconiwa...
       # Hooks won't work
       pidfile = "/tmp/.__criu_restored_#{@base.name}.pid"
-      cmds = RestoreCMD.new(checkpoint.criu_bin_path)[
-        , "restore",
-      cmds.options << "--shell-job",
+      cmds = RestoreCMD.new(checkpoint.criu_bin_path)
+      cmds.options << "--shell-job"
       cmds.options.concat ["--pidfile", pidfile] # FIXME: shouldn't criu cli pass its pid via envvar?
       cmds.options.concat ["-D",checkpoint.images_dir]
       self_exe = File.readlink "/proc/self/exe"

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -99,6 +99,9 @@ module Haconiwa
 
       unless @base.filesystem.mount_points.empty?
         cmds.externals << "mnt[]:"
+        @base.filesystem.external_mount_points.each do |mp|
+          cmds.externals << "mnt[#{mp.criu_ext_key}]:#{mp.src}"
+        end
       end
 
       # Order of external...

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -46,45 +46,72 @@ module Haconiwa
       end
     end
 
+    class RestoreCMD
+      def initialize(bin_path)
+        @bin_path = bin_path
+        @options = []
+        @externals = []
+        @run_exec_cmd = true
+        @exec_cmd = nil
+      end
+      attr_accessor :options, :externals, :exec_cmd
+
+      def to_execve_arg
+        [
+          @bin_path,
+          "restore"
+        ] + rest_arguments
+      end
+      alias inspect to_execve_arg
+
+      def rest_arguments
+        a = @options.dup
+        @externals.each do |opt|
+          a.concat(["--external", opt])
+        end
+        if @exec_cmd
+          a.concat(["--exec-cmd", "--"])
+          a.concat(@exec_cmd.dup)
+        end
+        a
+      end
+    end
+
     def restore
       # TODO: embed criu(crtools) to haconiwa...
       # Hooks won't work
       pidfile = "/tmp/.__criu_restored_#{@base.name}.pid"
-      cmds = [
-        checkpoint.criu_bin_path, "restore",
-        "--shell-job",
-        "--pidfile", pidfile, # FIXME: shouldn't criu cli pass its pid via envvar?
-        "-D", checkpoint.images_dir
-      ]
+      cmds = RestoreCMD.new(checkpoint.criu_bin_path)[
+        , "restore",
+      cmds.options << "--shell-job",
+      cmds.options.concat ["--pidfile", pidfile] # FIXME: shouldn't criu cli pass its pid via envvar?
+      cmds.options.concat ["-D",checkpoint.images_dir]
       self_exe = File.readlink "/proc/self/exe"
 
       nw = @base.network
       if nw.enabled?
         external_string = "veth[#{nw.veth_guest}]:#{nw.veth_host}@#{nw.bridge_name}"
-        cmds.concat(["--external", external_string])
+        cmds.externals << external_string
 
         ENV['HACONIWA_NEW_IP'] = nw.container_ip_with_netmask
         ENV['HACONIWA_RUN_AS_CRIU_ACTION_SCRIPT'] = "true"
       end
 
       unless @base.filesystem.mount_points.empty?
-        cmds.concat(["--external", "mnt[]:"])
+        cmds.externals << "mnt[]:"
       end
 
       # Order of external...
       # FIXME make this command generator a class
       if nw.enabled?
-        cmds.concat(["--action-script", self_exe])
+        cmds.options.concat(["--action-script", self_exe])
       end
 
-      cmds.concat(
-        [
-          "--root", @base.filesystem.root_path,
-          "--exec-cmd",
-          "--", self_exe, "_restored", @base.hacofile, pidfile
-        ])
+      cmds.options.concat(["--root", @base.filesystem.root_path])
+      cmds.exec_cmd = [self_exe, "_restored", @base.hacofile, pidfile]
+
       Haconiwa::Logger.debug("Going to exec: #{cmds.inspect}")
-      ::Exec.execve(ENV, *cmds)
+      ::Exec.execve(ENV, *cmds.to_execve_arg)
     end
   end
 end

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -46,6 +46,7 @@ Haconiwa.define do |config|
       c.set_log_file base.checkpoint.criu_log_file
       c.set_shell_job true
       c.add_external "mnt[]"
+      c.add_external "mnt[/home/test-account]:my-homedir-1"
       begin
         c.set_pid base.pid
         c.dump
@@ -71,7 +72,8 @@ Haconiwa.define do |config|
   config.mount_independent "sysfs"
   config.mount_independent "devpts"
   config.mount_independent "shm"
-  config.add_mount_point "/home/vagrant", to: root.join("home/test-account")
+  config.add_mount_point "/home/vagrant", to: root.join("home/test-account"),
+                         criu_ext_key: "my-homedir-1"
 
   config.namespace.unshare "mount"
   config.namespace.unshare "uts"


### PR DESCRIPTION
We use '`--external mnt[]:` to automatically detect external bind mounts, but in some case it fails, especially when we use NFS and bind-mount it.

These options are to fight against this kind of use case.