### PR TITLE
Implement masked paths

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -802,13 +802,18 @@ module Haconiwa
   end
 
   class Filesystem
+    MASKED_PATHS_DEFAULT = [
+    ]
+
     def initialize
       @mount_points = []
       @independent_mount_points = []
+      @masked_paths = MASKED_PATHS_DEFAULT
       @rootfs = Rootfs.new(nil)
     end
     attr_accessor :mount_points,
                   :independent_mount_points,
+                  :masked_paths,
                   :rootfs
 
     FS_TO_MOUNT = {
@@ -833,6 +838,10 @@ module Haconiwa
       end
 
       self.independent_mount_points << MountPoint.new(params[1], to: params[2], fs: params[0])
+    end
+
+    def add_masked_path(path)
+      @masked_paths << path
     end
   end
 

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -149,6 +149,10 @@ module Haconiwa
       filesystem.rootfs
     end
 
+    def hashed_name
+      ::SHA1.sha1_hex(self.name)[0, 16]
+    end
+
     def support_reload(*names)
       names.each do |name|
         unless [:cgroup, :resource].include?(name)
@@ -803,6 +807,15 @@ module Haconiwa
 
   class Filesystem
     MASKED_PATHS_DEFAULT = [
+      "/proc/acpi",
+      "/proc/kcore",
+      "/proc/keys",
+      "/proc/latency_stats",
+      "/proc/timer_list",
+      "/proc/timer_stats",
+      "/proc/sched_debug",
+      "/proc/scsi",
+      "/sys/firmware"
     ]
 
     def initialize

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -134,6 +134,7 @@ module Haconiwa
             invoke_general_hook(:before_chroot, base)
 
             do_chroot(base)
+            apply_masked_paths(base.filesystem)
             Logger.debug("OK: do_chroot")
             invoke_general_hook(:after_chroot, base)
 
@@ -264,6 +265,13 @@ module Haconiwa
         Logger.puts "Process successfully exited: #{status.inspect}"
       else
         Logger.warning "Process failed: #{status.inspect}"
+      end
+    end
+
+    def apply_masked_paths(filesystem)
+      # This will run in chroot
+      filesystem.masked_paths.each do |path|
+        Mount.bind_mount "/dev/null", path, {}
       end
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -268,10 +268,15 @@ module Haconiwa
       end
     end
 
-    def apply_masked_paths(filesystem)
-      # This will run in chroot
-      filesystem.masked_paths.each do |path|
-        Mount.bind_mount "/dev/null", path, {}
+    def apply_masked_paths(base)
+      base.filesystem.masked_paths.each do |path|
+        if File.exist? path
+          if File.directory? path
+            Mount.mount 'empty', path, type: 'tmpfs'
+          else
+            Mount.bind_mount "/dev/null", path, {}
+          end
+        end
       end
     end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -134,7 +134,7 @@ module Haconiwa
             invoke_general_hook(:before_chroot, base)
 
             do_chroot(base)
-            apply_masked_paths(base.filesystem)
+            apply_masked_paths(base)
             Logger.debug("OK: do_chroot")
             invoke_general_hook(:after_chroot, base)
 


### PR DESCRIPTION
## Usage:

```ruby
config.filesystem.masked_paths = [
  "/dev/foo",
  "/proc/bar",
  ...
]
```

Then these paths are masked in a container