### PR TITLE
Implement before and after restore hooks

### DIFF
--- a/mrblib/haconiwa/00_hookable.rb
+++ b/mrblib/haconiwa/00_hookable.rb
@@ -1,0 +1,31 @@
+module Haconiwa
+  module Hookable
+    VALID_HOOKS = [
+      :setup,
+      :before_fork,
+      :after_fork,
+      :before_chroot,
+      :after_chroot,
+      :before_start_wait,
+      :teardown_container,
+      :teardown,
+      :after_reload,
+      :after_failure,
+      :system_failure,
+      :before_restore,
+      :after_restore,
+    ]
+
+    def self.valid?(hookpoint)
+      VALID_HOOKS.include?(hookpoint)
+    end
+
+    def invoke_general_hook(hookpoint, base)
+      hook = base.general_hooks[hookpoint]
+      hook.call(base) if hook
+    rescue Exception => e
+      Logger.warning("General container hook at #{hookpoint.inspect} failed. Skip")
+      Logger.warning("#{e.class} - #{e.message}")
+    end
+  end
+end

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -224,7 +224,7 @@ module Haconiwa
     end
 
     def add_general_hook(hookpoint, &b)
-      raise("Invalid hook point: #{hookpoint.inspect}") unless LinuxRunner::VALID_HOOKS.include?(hookpoint.to_sym)
+      raise("Invalid hook point: #{hookpoint.inspect}") unless Hookable.valid?(hookpoint.to_sym)
       @general_hooks[hookpoint.to_sym] = b
     end
 

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -128,8 +128,18 @@ module Haconiwa
 
       cmds.exec_cmd = [self_exe, "_restored", @base.hacofile, pidfile]
 
+      invoke_general_hook(:before_restore, @base)
       Haconiwa::Logger.debug("Going to exec: #{cmds.inspect}")
       ::Exec.execve(ENV, *cmds.to_execve_arg)
+    end
+
+    # FIXME: make it a module...
+    def invoke_general_hook(hookpoint, base)
+      hook = base.general_hooks[hookpoint]
+      hook.call(base) if hook
+    rescue Exception => e
+      Logger.warning("General container hook at #{hookpoint.inspect} failed. Skip")
+      Logger.warning("#{e.class} - #{e.message}")
     end
   end
 end

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -1,5 +1,7 @@
 module Haconiwa
   class CRIUService
+    include Hookable
+
     def initialize(base)
       @base = base
     end
@@ -131,15 +133,6 @@ module Haconiwa
       invoke_general_hook(:before_restore, @base)
       Haconiwa::Logger.debug("Going to exec: #{cmds.inspect}")
       ::Exec.execve(ENV, *cmds.to_execve_arg)
-    end
-
-    # FIXME: make it a module...
-    def invoke_general_hook(hookpoint, base)
-      hook = base.general_hooks[hookpoint]
-      hook.call(base) if hook
-    rescue Exception => e
-      Logger.warning("General container hook at #{hookpoint.inspect} failed. Skip")
-      Logger.warning("#{e.class} - #{e.message}")
     end
   end
 end

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -1,26 +1,12 @@
 module Haconiwa
   class Runner
+    include Hookable
+
     def initialize(base)
       @base = base
       @pid_file = nil
       validate_ruid(base)
     end
-
-    VALID_HOOKS = [
-      :setup,
-      :before_fork,
-      :after_fork,
-      :before_chroot,
-      :after_chroot,
-      :before_start_wait,
-      :teardown_container,
-      :teardown,
-      :after_reload,
-      :after_failure,
-      :system_failure,
-      :before_restore,
-      :after_restore,
-    ]
 
     LOCKFILE_DIR = "/var/lock"
 
@@ -341,14 +327,6 @@ module Haconiwa
           raise "Invalid user/group to invoke suid-haconiwa: #{::Process::Sys.getuid}:#{::Process::Sys.getgid}"
         end
       end
-    end
-
-    def invoke_general_hook(hookpoint, base)
-      hook = base.general_hooks[hookpoint]
-      hook.call(base) if hook
-    rescue Exception => e
-      Logger.warning("General container hook at #{hookpoint.inspect} failed. Skip")
-      Logger.warning("#{e.class} - #{e.message}")
     end
 
     private

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -67,6 +67,14 @@ Haconiwa.define do |config|
     end
   end
 
+  config.add_general_hook :before_restore do |base|
+    Haconiwa::Logger.info "Now in :before_restore!"
+  end
+
+  config.add_general_hook :after_restore do |base|
+    Haconiwa::Logger.info "Now in :after_restore! PID=#{base.pid}"
+  end
+
   config.mount_independent "procfs"
   config.mount_independent "devtmpfs"
   config.mount_independent "sysfs"


### PR DESCRIPTION
Please see example:

```ruby
  config.add_general_hook :before_restore do |base|
    Haconiwa::Logger.info "Now in :before_restore!"
  end

  config.add_general_hook :after_restore do |base|
    Haconiwa::Logger.info "Now in :after_restore! PID=#{base.pid}"
  end
```

```
Oct  4 09:26:42 foo haconiwa.chroot-rails001-[28408]: Now in :before_restore!                                                                     
Oct  4 09:26:42 foo haconiwa.chroot-rails001-[28408]: Going to exec: ["/usr/local/sbin/criu", "restore",... ]
...
Oct  4 09:26:43 foo haconiwa.chroot-rails001-[28408]: Now in exec'ed haconiwa supervisor process
Oct  4 09:26:43 foo haconiwa.chroot-rails001-[28408]: Now in :after_restore! PID=28413
Oct  4 09:26:43 foo haconiwa.chroot-rails001-[28408]: WaitLoop instance status: #<Haconiwa::WaitLoop:0x55d561336470 @wait_interval=5, @mainloop=#<F
iberedWorker::MainLoop:0x55d5613363e0>>
Oct  4 09:26:43 foo haconiwa.chroot-rails001-[28408]: Container fork success and going to wait: pid=28413
```

Both before_restore and after_restore are only invoked in `hacvoniwa restore`.