### PR TITLE
Implement checkpoint--running/--target=PID option

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1018,7 +1018,7 @@ module Haconiwa
     end
 
     def veth_guest
-      @veth_guest ||= ::SHA1.sha1_hex(self.namespace)[0, 8] + '_g'
+      @veth_guest ||= "veth0"
     end
 
     def container_ip_with_netmask

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -353,13 +353,18 @@ module Haconiwa
       raise "Kill does not seem to be completed. Check process of PID=#{::File.read supervisor_all_pid_file}"
     end
 
-    def do_checkpoint(*cmd)
+    def do_checkpoint(target_pid=nil)
       target = containers_real_run
       if target.size != 1
         raise "Checkpoint now does not support multiple containers"
       end
 
-      Haconiwa::CRIUService.new(target.first).create_checkpoint
+      if !target_pid
+        CRIUService.new(target.first).create_checkpoint
+      else
+        service = CRIUService::DumpViaAPI.new(target.first)
+        service.dump(target_pid)
+      end
     end
 
     def restore(*_a)

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1077,6 +1077,11 @@ module Haconiwa
         @target_syscall = args
       end
     end
+
+    def dump(base, opt={})
+      service = CRIUService::DumpViaAPI.new(base)
+      service.dump(opt[:pid] || base.pid)
+    end
   end
 
   def self.define(&b)

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -116,8 +116,14 @@ module Haconiwa
 
     def self.checkpoint(args)
       opt = parse_opts(args, 'HACO_FILE') do |o|
+        o.integer('t', 'target', 'PID', "Container's *root* PID to make checkpoint.")
       end
-      get_base(opt.catchall.values).do_checkpoint
+      target_pid = if opt['t'].exist?
+                     opt['t'].value
+                   else
+                     nil
+                   end
+      get_base(opt.catchall.values).do_checkpoint(target_pid)
     end
 
     def self.restore(args)

--- a/mrblib/haconiwa/cli.rb
+++ b/mrblib/haconiwa/cli.rb
@@ -116,10 +116,13 @@ module Haconiwa
 
     def self.checkpoint(args)
       opt = parse_opts(args, 'HACO_FILE') do |o|
-        o.integer('t', 'target', 'PID', "Container's *root* PID to make checkpoint.")
+        o.literal('R', 'running', "Create checkpoint of running container. Detect container's PID via hacofile(in case without --target)")
+        o.integer('t', 'target', 'PID', "Container's *root* PID to make checkpoint. This implies --running")
       end
       target_pid = if opt['t'].exist?
                      opt['t'].value
+                   elsif opt['R'].exist?
+                     0
                    else
                      nil
                    end

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -48,6 +48,31 @@ module Haconiwa
       end
     end
 
+    class DumpViaAPI
+      def initialize(base)
+        @base = base
+      end
+      attr_accessor :options, :externals
+
+      def dump(target_pid)
+        c = CRIU.new
+        c.set_images_dir @base.checkpoint.images_dir
+        c.set_service_address @base.checkpoint.criu_service_address
+        c.set_log_file @base.checkpoint.criu_log_file
+        c.set_shell_job true
+
+        unless @base.filesystem.mount_points.empty?
+          c.add_external "mnt[]:"
+          @base.filesystem.external_mount_points.each do |mp|
+            c.add_external << "mnt[#{mp.dest}]:#{mp.criu_ext_key}"
+          end
+        end
+
+        c.set_pid target_pid
+        c.dump
+      end
+    end
+
     class RestoreCMD
       def initialize(bin_path)
         @bin_path = bin_path

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -64,7 +64,7 @@ module Haconiwa
         unless @base.filesystem.mount_points.empty?
           c.add_external "mnt[]:"
           @base.filesystem.external_mount_points.each do |mp|
-            c.add_external << "mnt[#{mp.dest}]:#{mp.criu_ext_key}"
+            c.add_external "mnt[#{mp.dest}]:#{mp.criu_ext_key}"
           end
         end
 

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -224,7 +224,7 @@ module Haconiwa
       if !base.pid
         begin
           ppid = ::Pidfile.pidof(base.container_pid_file)
-          base.pid = ppid_to_pid(ppid)
+          base.pid = Util.ppid_to_pid(ppid)
         rescue => e
           Logger.exception "PID detecting failed: #{e.class}, #{e.message}. It seems you should specify container PID by -t option"
         end
@@ -287,7 +287,7 @@ module Haconiwa
       if !@base.pid
         begin
           ppid = ::Pidfile.pidof(@base.container_pid_file)
-          @base.pid = ppid_to_pid(ppid)
+          @base.pid = Util.ppid_to_pid(ppid)
         rescue => e
           Logger.exception "PID detecting failed: #{e.class}, #{e.message}. It seems you should specify container PID by -t option"
         end
@@ -330,14 +330,6 @@ module Haconiwa
     end
 
     private
-
-    def ppid_to_pid(ppid)
-      status = `find /proc -maxdepth 2 -regextype posix-basic -regex '/proc/[0-9]\\+/status'`.
-               split.
-               find {|f| File.read(f).include? "PPid:\t#{ppid}\n" rescue false }
-      raise(HacoFatalError, "Container PID not found by find") unless status
-      status.split('/')[2].to_i
-    end
 
     def raise_container(&b)
       b.call(@base)

--- a/mrblib/haconiwa/util.rb
+++ b/mrblib/haconiwa/util.rb
@@ -22,5 +22,13 @@ module Haconiwa
     def safe_shell_fmt(fmt, *args)
       sprintf(fmt, *to_safe_shellargs(args))
     end
+
+    def ppid_to_pid(ppid)
+      status = `find /proc -maxdepth 2 -regextype posix-basic -regex '/proc/[0-9]\\+/status'`.
+               split.
+               find {|f| ::File.read(f).include? "PPid:\t#{ppid}\n" rescue false }
+      raise(HacoFatalError, "Container PID not found by find") unless status
+      status.split('/')[2].to_i
+    end
   end
 end

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -35,7 +35,6 @@ Haconiwa.define do |config|
   else
     config.network.container_ip = "10.0.0.3"
   end
-  config.network.veth_guest = "veth0" # Fixed
   config.network.veth_host = ::SHA1.sha1_hex(config.name + config.network.container_ip)[0, 8] + '_h'
 
   if ::Haconiwa.current_subcommand != "_restored"

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -25,7 +25,7 @@ Haconiwa.define do |config|
     checkpoint.target_syscall :listen, 0
     checkpoint.images_dir    = "/tmp/criu/images.rails"
     checkpoint.log_level     = 3
-    checkpoint.criu_log_file = "/var/log/criu-restore.log"
+    checkpoint.criu_log_file = "-"
     checkpoint.criu_service_address = "/var/run/criu_service.socket"
   end
 
@@ -40,19 +40,11 @@ Haconiwa.define do |config|
 
   if ::Haconiwa.current_subcommand != "_restored"
     config.add_async_hook msec: 2500 do |base|
-      c = CRIU.new
-      puts base.checkpoint.images_dir
-      c.set_images_dir base.checkpoint.images_dir
-      c.set_service_address base.checkpoint.criu_service_address
-      c.set_log_file base.checkpoint.criu_log_file
-      c.set_shell_job true
-      c.add_external "mnt[]"
-      c.add_external "mnt[/home/test-account]:my-homedir-1"
       begin
-        c.set_pid base.pid
-        c.dump
+        base.checkpoint.dump base
       rescue => e
         Haconiwa::Logger.puts "CRIU[hook]: dump failed: #{e.class}, #{e.message}"
+        ::Process.kill :TERM, base.pid
       else
         Haconiwa::Logger.puts "CRIU[hook]: dump OK!!"
       end


### PR DESCRIPTION
This allows users to dump running containers.

```console
$ sudo ./mruby/bin/haconiwa checkpoint --help
 -R, --running             Create checkpoint of running container. Detect container's PID via hacofile(in case without --target)
 -t, --target=PID          Container's *root* PID to make checkpoint. This implies --running
 -h, --help                Show help
 HACO_FILE                 Put the config file at the end of command
```