### PR TITLE
Use chrooted_dest instead as mnt[*]'s key

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1111,7 +1111,7 @@ module Haconiwa
     end
 
     def chrooted_dest(newroot)
-      @dest.sub(/^#{newroot}/, "")
+      @dest.sub(/^#{newroot.to_s}/, "")
     end
   end
 

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -64,7 +64,7 @@ module Haconiwa
         unless @base.filesystem.mount_points.empty?
           c.add_external "mnt[]:"
           @base.filesystem.external_mount_points.each do |mp|
-            c.add_external "mnt[#{mp.dest}]:#{mp.criu_ext_key}"
+            c.add_external "mnt[#{mp.chrooted_dest(@base.root_path)}]:#{mp.criu_ext_key}"
           end
         end
 


### PR DESCRIPTION
Ref: https://criu.org/External_bind_mounts

Path to be specified in `--external` should not be Host path.
