### PR TITLE
Do not set `+`, this implies `O_RDWR`.

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -627,16 +627,16 @@ module Haconiwa
 
       def to_io
         if !target_file
-          return File.open(DEVNULL, 'a')
+          return File.open(DEVNULL, 'w')
         end
-        File.open(target_file, 'a+')
+        File.open(target_file, 'a')
       end
 
       def to_io_readonly
         if !target_file
           return File.open(DEVNULL, 'r')
         end
-        File.open(target_file, 'r+')
+        File.open(target_file, 'r')
       end
     end
 


### PR DESCRIPTION
- For logs, use `O_WRONLY` and `O_APPEND`. `a` fits this.
- This is MUST to restore log fds via CRIU