### PR TITLE
Refactor logger

### DIFF
--- a/mrblib/haconiwa/action_script.rb
+++ b/mrblib/haconiwa/action_script.rb
@@ -4,7 +4,7 @@ module Haconiwa
       return 0
     end
     log_level = ( ENV['DEBUG'] || ENV['VERBOSE'] ) ? Haconiwa::Logger::DEBUG : Haconiwa::Logger::INFO
-    ::Syslog._setup("haconiwa.action-script", log_level)
+    Haconiwa::Logger.instance._setup("haconiwa.action-script", log_level)
 
     dev_name_line = `nsenter --net -t #{ENV['CRTOOLS_INIT_PID']} ip addr show`.lines.
                       select {|l| l =~ /^[0-9]+:/ }.

--- a/mrblib/haconiwa/action_script.rb
+++ b/mrblib/haconiwa/action_script.rb
@@ -3,7 +3,8 @@ module Haconiwa
     if ENV['CRTOOLS_SCRIPT_ACTION'] != "post-setup-namespaces"
       return 0
     end
-    ::Syslog.open("haconiwa.action-script")
+    log_level = ( ENV['DEBUG'] || ENV['VERBOSE'] ) ? Haconiwa::Logger::DEBUG : Haconiwa::Logger::INFO
+    ::Syslog._setup("haconiwa.action-script", log_level)
 
     dev_name_line = `nsenter --net -t #{ENV['CRTOOLS_INIT_PID']} ip addr show`.lines.
                       select {|l| l =~ /^[0-9]+:/ }.

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -417,13 +417,14 @@ module Haconiwa
       if target.size != 1
         raise "[BUG] Checkpoint now does not support multiple containers"
       end
+      con = target.first
 
-      target.container_pid_file ||= default_container_pid_file
+      con.container_pid_file ||= default_container_pid_file
       pid = File.open(pidfile_path, 'r').read.to_i
-      target.pid = pid
+      con.pid = pid
       File.unlink(pidfile_path)
 
-      CRIURestoredRunner.new(target).run({restored_pid: pid}, nil)
+      CRIURestoredRunner.new(con).run({restored_pid: pid}, nil)
       Haconiwa::Logger.puts("Restored process exited")
     rescue => e
       Haconiwa::Logger.warning("Something is wrong on re-supervise process(This is haconiwa's bug, not image's)")

--- a/mrblib/haconiwa/logger.rb
+++ b/mrblib/haconiwa/logger.rb
@@ -12,10 +12,12 @@ module Haconiwa
       end
 
       def set_default_instance!(logger)
+        old = @instance
         @instance = logger
+        return old
       end
 
-      %(exception err warning notice info puts debug).each do |meth|
+      %w(setup exception err warning notice info puts debug).each do |meth|
         define_method(meth) do |*arg|
           instance.__send__(meth, *arg)
         end
@@ -24,6 +26,9 @@ module Haconiwa
 
     class SyslogLogger
       def initialize
+        if Syslog.opened?
+          Syslog.close
+        end
         Syslog.open("haconiwa")
         @log_level = INFO
       end
@@ -37,7 +42,7 @@ module Haconiwa
           Syslog.close
         end
         Syslog.open("haconiwa.#{name}")
-        @log_level = [log_level, ERROR].min
+        @log_level = [level, ERROR].min
       end
 
       # Calling this will stop haconiwa process

--- a/mrblib/haconiwa/logger.rb
+++ b/mrblib/haconiwa/logger.rb
@@ -6,61 +6,87 @@ module Haconiwa
     WARNING = 3
     ERROR   = 4
 
-    extend self
-    def setup(base)
-      if Syslog.opened?
-        Syslog.close
+    class << self
+      def instance
+        @instance ||= SyslogLogger.new
       end
-      Syslog.open("haconiwa.#{base.name}")
-      @log_level = [base.log_level, ERROR].min
-    end
 
-    # Calling this will stop haconiwa process
-    def exception(*args)
-      if args.first.is_a? HacoFatalError
-        e = args.first
-        err("An exception is occurred when spawning haconiwa:")
-        err("#{e.inspect}")
-        e.backtrace[1..-1].each{|l| err "=> #{l}" } if e.backtrace
-        err("...Shutting down haconiwa")
-        raise(e)
-      elsif args.first.is_a? Exception
-        e = args.first
-        err("#{e.inspect}")
-        err("=> #{e.backtrace.first}") if e.backtrace
-        raise(HacoFatalError, e.inspect)
-      else
-        err(*args)
-        raise(HacoFatalError, *args)
+      def set_default_instance!(logger)
+        @instance = logger
+      end
+
+      %(exception err warning notice info puts debug).each do |meth|
+        define_method(meth) do |*arg|
+          instance.__send__(meth, *arg)
+        end
       end
     end
 
-    def err(*args)
-      Syslog.err(*args) if @log_level <= ERROR
-    end
+    class SyslogLogger
+      def initialize
+        Syslog.open("haconiwa")
+        @log_level = INFO
+      end
 
-    # Warning is forced to be teed to stderr
-    def warning(*args)
-      Syslog.warning(*args) if @log_level <= WARNING
-      STDERR.puts(*args)
-    end
+      def setup(base)
+        _setup(base.name, base.log_level)
+      end
 
-    def notice(*args)
-      Syslog.notice(*args) if @log_level <= NOTICE
-    end
+      def _setup(name, level)
+        if Syslog.opened?
+          Syslog.close
+        end
+        Syslog.open("haconiwa.#{name}")
+        @log_level = [log_level, ERROR].min
+      end
 
-    def info(*args)
-      Syslog.info(*args) if @log_level <= INFO
-    end
+      # Calling this will stop haconiwa process
+      def exception(*args)
+        if args.first.is_a? HacoFatalError
+          e = args.first
+          err("An exception is occurred when spawning haconiwa:")
+          err("#{e.inspect}")
+          e.backtrace[1..-1].each{|l| err "=> #{l}" } if e.backtrace
+          err("...Shutting down haconiwa")
+          raise(e)
+        elsif args.first.is_a? Exception
+          e = args.first
+          err("#{e.inspect}")
+          err("=> #{e.backtrace.first}") if e.backtrace
+          raise(HacoFatalError, e.inspect)
+        else
+          err(*args)
+          raise(HacoFatalError, *args)
+        end
+      end
 
-    # Teeing log to stdout
-    def puts(*args)
-      info(*args)
-      Kernel.puts(*args)
-    end
+      def err(*args)
+        Syslog.err(*args) if @log_level <= ERROR
+      end
 
-    def debug(*args)
-      Syslog.debug(*args) if @log_level <= DEBUG
+      # Warning is forced to be teed to stderr
+      def warning(*args)
+        Syslog.warning(*args) if @log_level <= WARNING
+        STDERR.puts(*args)
+      end
+
+      def notice(*args)
+        Syslog.notice(*args) if @log_level <= NOTICE
+      end
+
+      def info(*args)
+        Syslog.info(*args) if @log_level <= INFO
+      end
+
+      # Teeing log to stdout
+      def puts(*args)
+        info(*args)
+        Kernel.puts(*args)
+      end
+
+      def debug(*args)
+        Syslog.debug(*args) if @log_level <= DEBUG
+      end
     end
   end
 end

--- a/sample/criu.haco
+++ b/sample/criu.haco
@@ -1,41 +1,51 @@
 # -*- mode: ruby -*-
-Haconiwa.define do |config|
-  config.name = "chroot-apache001" # to be hostname
-  config.init_command = %w(/usr/local/apache2/bin/httpd -DFOREGROUND -X)
-  # config.init_command = %w(/usr/local/bin/httpd-foreground)
-  config.daemonize!
-  config.command.set_stdout(file: "/tmp/container-internal.out")
-  config.command.set_stderr(file: "/tmp/container-internal.err")
+Haconiwa.define do |conf|
+  conf.define do |config|
+    config.name = "chroot-apache001" # to be hostname
+    config.init_command = %w(/usr/local/apache2/bin/httpd -DFOREGROUND -X)
+    # config.init_command = %w(/usr/local/bin/httpd-foreground)
+    config.daemonize!
+    config.command.set_stdout(file: "/tmp/container-internal.out")
+    config.command.set_stderr(file: "/tmp/container-internal.err")
 
-  root = Pathname.new("/var/lib/haconiwa-apache001")
-  config.chroot_to root
-  config.environ = {
-    "PATH" => "#{ENV['PATH']}",
-  }
+    root = Pathname.new("/var/lib/haconiwa-apache001")
+    config.chroot_to root
+    config.environ = {
+      "PATH" => "#{ENV['PATH']}",
+    }
 
-  system "mkdir -p /tmp/criu/images"
+    system "mkdir -p /tmp/criu/images"
 
-  config.network.namespace = config.name
-  config.network.container_ip = "10.0.0.2"
+    config.network.namespace = config.name
+    config.network.container_ip = "10.0.0.2"
 
-  config.checkpoint do |checkpoint|
-    checkpoint.target_syscall :listen, 0
-    checkpoint.images_dir    = "/tmp/criu/images"
-    checkpoint.criu_log_file = "-"
-    checkpoint.criu_service_address = "/var/run/criu_service.socket"
+    config.checkpoint do |checkpoint|
+      checkpoint.target_syscall :listen, 0
+      checkpoint.images_dir    = "/tmp/criu/images"
+      checkpoint.criu_log_file = "-"
+      checkpoint.criu_service_address = "/var/run/criu_service.socket"
+    end
+
+    config.namespace.unshare "uts"
+    config.namespace.unshare "ipc"
+    config.namespace.unshare "pid"
+    config.namespace.unshare "mount"
+
+    config.mount_independent "procfs"
+    config.mount_independent "devtmpfs"
+    config.capabilities.reset_to_privileged!
+
+    config.add_async_hook(sec: 10, interval_msec: 10 * 1000) do
+      Haconiwa::Logger.puts "Hi! #{`date`}"
+    end
+
+    config.add_general_hook(:teardown_container) do |b|
+      Haconiwa::Logger.puts "Exit! #{b.exit_status}"
+    end
   end
-
-  config.namespace.unshare "uts"
-  config.namespace.unshare "ipc"
-  config.namespace.unshare "pid"
-  config.namespace.unshare "mount"
-
-  config.mount_independent "procfs"
-  config.mount_independent "devtmpfs"
-  config.capabilities.reset_to_privileged!
 
   if File.exist? "/tmp/criu/images/core-1.img"
     Haconiwa::Logger.info "Going to run in restore mode"
-    config.run_as_restore = true
+    conf.run_as_restore = true
   end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,0 +1,75 @@
+class OnMemoryLogger
+  class MyError < StandardError
+  end
+
+  def initialize
+    @store = {}
+  end
+  attr_reader :store
+
+  def exception(*args)
+    err(*args)
+    raise(MyError)
+  end
+
+  def err(*args)
+    @store[:err] = args
+  end
+
+  def warning(*args)
+    @store[:warning] = args
+  end
+
+  def notice(*args)
+    @store[:notice] = args
+  end
+
+  def info(*args)
+    @store[:info] = args
+  end
+
+  def puts(*args)
+    info(*args)
+    @store[:stdout] = args
+  end
+
+  def debug(*args)
+    @store[:debug] = args
+  end
+end
+
+assert("Haconiwa::Logger") do
+  Haconiwa::Logger.instance # initialize
+  old = Haconiwa::Logger.set_default_instance!(OnMemoryLogger.new)
+
+  Haconiwa::Logger.err("test", "error")
+  assert_equal(["test", "error"], Haconiwa::Logger.instance.store[:err])
+
+  Haconiwa::Logger.warning("test", "warning")
+  assert_equal(["test", "warning"], Haconiwa::Logger.instance.store[:warning])
+
+  Haconiwa::Logger.notice("test", "notice")
+  assert_equal(["test", "notice"], Haconiwa::Logger.instance.store[:notice])
+
+  Haconiwa::Logger.info("test", "info")
+  assert_equal(["test", "info"], Haconiwa::Logger.instance.store[:info])
+
+  Haconiwa::Logger.debug("test", "debug")
+  assert_equal(["test", "debug"], Haconiwa::Logger.instance.store[:debug])
+
+  Haconiwa::Logger.puts("test", "puts")
+  assert_equal(["test", "puts"], Haconiwa::Logger.instance.store[:info])
+  assert_equal(["test", "puts"], Haconiwa::Logger.instance.store[:stdout])
+
+  err = nil
+  begin
+    Haconiwa::Logger.exception("test", "raise")
+  rescue => e
+    err = e
+  end
+
+  assert_equal(["test", "raise"], Haconiwa::Logger.instance.store[:err])
+  assert_equal(OnMemoryLogger::MyError, e.class)
+
+  Haconiwa::Logger.set_default_instance!(old)
+end


### PR DESCRIPTION
`Haconiwa::Logger.*` cannot be called in condition where `Haconiwa::Base` is not set up.

This is unuseful in some case (action script, top-level Hacofile logging). So I rewrite logging code in singleton pattern and lazy initialization.