### PR TITLE
Run the action script of resetting IP after fds are restored

### DIFF
--- a/mrblib/haconiwa/action_script.rb
+++ b/mrblib/haconiwa/action_script.rb
@@ -1,6 +1,6 @@
 module Haconiwa
   def self.run_as_criu_action_script
-    if ENV['CRTOOLS_SCRIPT_ACTION'] != "post-setup-namespaces"
+    if ENV['CRTOOLS_SCRIPT_ACTION'] != "post-restore"
       return 0
     end
     log_level = ( ENV['DEBUG'] || ENV['VERBOSE'] ) ? Haconiwa::Logger::DEBUG : Haconiwa::Logger::INFO


### PR DESCRIPTION
If run the iproute2 scripts on `post-setup-namespaces`, this inhivits already listened sockets to be restored.

`post-resume` may work...