### PR TITLE
Release 0.10.0

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -379,6 +379,7 @@ module Haconiwa
 
       base = target.first
       if !target_pid
+        Haconiwa::Logger.puts "Warning: feature of checkpoint from scratch boot is alpha version"
         CRIUService.new(base).create_checkpoint
       else
         if target_pid <= 0

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -617,7 +617,7 @@ module Haconiwa
 
       # TODO: support options other than file:
       def initialize(options={})
-        @file = options[:file]
+        @file = options[:container_file] || options[:file]
         @host_file = options[:host_file]
       end
       attr_accessor :file, :host_file

--- a/mrblib/haconiwa/version.rb
+++ b/mrblib/haconiwa/version.rb
@@ -1,3 +1,3 @@
 module Haconiwa
-  VERSION = "0.10.0.alpha5"
+  VERSION = "0.10.0"
 end

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,8 +1,8 @@
-haconiwa (0.10.0~alpha5-1) unstable; urgency=medium
+haconiwa (0.10.0-1) unstable; urgency=medium
 
-  * Alpha release of criu-included one
+  * First release with checkpoint/restore
 
- -- Uchio Kondo <udzura@udzura.jp>  Fri, 16 Nov 2018 17:59:36 +0900
+ -- Uchio Kondo <udzura@udzura.jp>  Mon, 28 Jan 2019 14:41:51 +0900
 
 haconiwa (0.9.6-1) unstable; urgency=medium
 

--- a/packages/dockerfiles/Dockerfile.bionic
+++ b/packages/dockerfiles/Dockerfile.bionic
@@ -13,11 +13,11 @@ RUN apt-get -qq -y install \
     dh-make xz-utils
 RUN apt-get -qq -y install criu
 
-ENV VERSION 0.10.0.alpha5
-ENV VERSION_TILDE 0.10.0~alpha5
+ENV VERSION 0.10.0
+ENV VERSION_TILDE 0.10.0
 ENV USER root
-ENV SRC_PKG_NAME haconiwa_0.10.0~alpha5-1_amd64.deb
-ENV DST_PKG_NAME haconiwa_0.10.0~alpha5-1+bionic_amd64.deb
+ENV SRC_PKG_NAME haconiwa_0.10.0-1_amd64.deb
+ENV DST_PKG_NAME haconiwa_0.10.0-1+bionic_amd64.deb
 VOLUME /out
 
 RUN mkdir -p /libexec

--- a/packages/dockerfiles/Dockerfile.centos
+++ b/packages/dockerfiles/Dockerfile.centos
@@ -18,7 +18,7 @@ RUN yum -q -y install \
 RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN sed -i "s;%_build_name_fmt.*;%_build_name_fmt\t%%{ARCH}/%%{NAME}-%%{VERSION}-%%{RELEASE}.el7.%%{ARCH}.rpm;" /usr/lib/rpm/macros
 
-ENV VERSION 0.10.0~alpha5
+ENV VERSION 0.10.0
 ENV USER root
 ENV HOME /root
 VOLUME /out

--- a/packages/dockerfiles/Dockerfile.debian
+++ b/packages/dockerfiles/Dockerfile.debian
@@ -15,8 +15,8 @@ RUN apt-get -qq -y install libprotobuf-dev libprotobuf-c0-dev \
     protobuf-c-compiler protobuf-compiler python-protobuf \
     libnl-3-dev libnet-dev libcap-dev pkg-config
 
-ENV VERSION 0.10.0.alpha5
-ENV VERSION_TILDE 0.10.0~alpha5
+ENV VERSION 0.10.0
+ENV VERSION_TILDE 0.10.0
 ENV USER root
 VOLUME /out
 

--- a/packages/dockerfiles/Dockerfile.debian9
+++ b/packages/dockerfiles/Dockerfile.debian9
@@ -15,10 +15,10 @@ RUN apt-get -qq -y install libprotobuf-dev libprotobuf-c0-dev \
     protobuf-c-compiler protobuf-compiler python-protobuf \
     libnl-3-dev libnet-dev libcap-dev pkg-config
 
-ENV VERSION 0.10.0~alpha5
+ENV VERSION 0.10.0
 ENV USER root
-ENV SRC_PKG_NAME haconiwa_0.10.0~alpha5-1_amd64.deb
-ENV DST_PKG_NAME haconiwa_0.10.0~alpha5-1+debian9_amd64.deb
+ENV SRC_PKG_NAME haconiwa_0.10.0-1_amd64.deb
+ENV DST_PKG_NAME haconiwa_0.10.0-1+debian9_amd64.deb
 VOLUME /out
 
 RUN ln -s /tmp/criu-build/lib/c /usr/local/include/criu

--- a/packages/rpm/haconiwa.spec
+++ b/packages/rpm/haconiwa.spec
@@ -1,6 +1,6 @@
 Name: haconiwa
 Epoch: 1
-Version: 0.10.0~alpha5
+Version: 0.10.0
 Release: 1
 Summary: MRuby on Container
 License: GPLv3+
@@ -49,8 +49,8 @@ fi
 %{_bindir}/*
 
 %changelog
-* Fri Nov 16 2018 Uchio Kondo <udzura@udzura.jp> - 1:0.10.0~alpha5-1
-- Alpha release of criu-included one
+* Mon Jan 28 2019 Uchio Kondo <udzura@udzura.jp> - 1:0.10.0-1
+- First release with checkpoint/restore
 
 * Mon Nov  5 2018 Uchio Kondo <udzura@udzura.jp> - 1:0.9.6-1
 - Fix missing chdir after chroot when using use_legacy_chroot

--- a/packages/templates/changelog.yml
+++ b/packages/templates/changelog.yml
@@ -1,10 +1,10 @@
-latest: 0.10.0~alpha5
+latest: 0.10.0
 changelog:
-  - version: 0.10.0~alpha5
+  - version: 0.10.0
     messages:
-      - Alpha release of criu-included one
+      - First release with checkpoint/restore
     author: Uchio Kondo <udzura@udzura.jp>
-    date: Fri, 16 Nov 2018 17:59:36 +0900
+    date: Mon, 28 Jan 2019 14:41:51 +0900
   - version: 0.9.6
     messages:
       - Fix missing chdir after chroot when using use_legacy_chroot


### PR DESCRIPTION
This enable haconiwa to run:

```
$ haconiwa checkpoint --running
$ haconiwa restore
```

NOTE that checkpoint without running container is still alpha version.