### PR TITLE
Add after-network_initialized hook to control networks

### DIFF
--- a/mrblib/haconiwa/00_hookable.rb
+++ b/mrblib/haconiwa/00_hookable.rb
@@ -4,6 +4,7 @@ module Haconiwa
       :setup,
       :before_fork,
       :after_fork,
+      :after_network_initialized,
       :before_chroot,
       :after_chroot,
       :before_start_wait,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -84,6 +84,7 @@ module Haconiwa
                 Logger.exception(e)
               end
             end
+            invoke_general_hook(:after_network_initialized, barn)
             apply_namespace(base.namespace)
 
             Logger.debug("OK: apply_namespace")

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -84,7 +84,7 @@ module Haconiwa
                 Logger.exception(e)
               end
             end
-            invoke_general_hook(:after_network_initialized, barn)
+            invoke_general_hook(:after_network_initialized, base)
             apply_namespace(base.namespace)
 
             Logger.debug("OK: apply_namespace")


### PR DESCRIPTION
This hook is invoked:

* just after container(inside) network is available, before any unshare
* invoked in container-to-be process