### PR TITLE
configure cgroup name and hostname individually

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -88,6 +88,7 @@ module Haconiwa
       @signal_handler = SignalHandler.new
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
+      @cgroup_name = nil
       @container_pid_file = nil
       @pid = nil
       @daemon = false
@@ -143,6 +144,14 @@ module Haconiwa
 
     def init_command
       self.command.init_command
+    end
+
+    def cgroup_name=(name)
+      @cgroup_name = name
+    end
+
+    def cgroup_name
+      @cgroup_name || @name
     end
 
     def acts_as_session_leader

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -88,7 +88,6 @@ module Haconiwa
       @signal_handler = SignalHandler.new
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
-      @cgroup_name = nil
       @container_pid_file = nil
       @pid = nil
       @daemon = false
@@ -147,11 +146,11 @@ module Haconiwa
     end
 
     def cgroup_name=(name)
-      @cgroup_name = name
+      @cgroup.name = name
     end
 
     def cgroup_name
-      @cgroup_name || @name
+      @cgroup.name || @name
     end
 
     def acts_as_session_leader
@@ -693,7 +692,7 @@ module Haconiwa
       @defblock = nil
     end
     attr_reader :groups, :groups_by_controller
-    attr_accessor :defblock
+    attr_accessor :defblock, :name
 
     def no_special_config?
       @groups.empty?

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -594,7 +594,7 @@ module Haconiwa
     end
 
     def reload(newcg, newcg2, newres)
-      LinuxRunner.new(self).reload(self.name, newcg, newcg2, newres, self.reloadable_attr)
+      LinuxRunner.new(self).reload(self.cgroup_name, newcg, newcg2, newres, self.reloadable_attr)
     end
 
     def kill(signame, timeout)

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -508,7 +508,7 @@ module Haconiwa
         Logger.debug "Creating cgroup controller #{controller}"
         Logger.exception("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
 
-        c = CG_MAPPING[controller].new(base.name)
+        c = CG_MAPPING[controller].new(base.cgroup_name)
         base.cgroup.groups_by_controller[controller].each do |pair|
           key, attr = pair
           value = base.cgroup[key]
@@ -561,7 +561,7 @@ module Haconiwa
       base.cgroup.controllers.each do |controller|
         Logger.exception("Invalid or unsupported controller name: #{controller}") unless CG_MAPPING.has_key?(controller)
 
-        c = CG_MAPPING[controller].new(base.name)
+        c = CG_MAPPING[controller].new(base.cgroup_name)
         c.delete
       end
     end


### PR DESCRIPTION
`config.name` で設定された値はhostnameとcgroup名に利用されていますが、これらを別々に設定したいです。
cgroup_nameを別に設定できるように機能追加しています

```
config.cgroup_name = "foobar"
```