### PR TITLE
Change install prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,4 @@ configure:
 	:
 
 install:
-	echo $(PREFIX)
 	rake install prefix=$(PREFIX)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 package = haconiwa
 CFLAGS = -std=gnu99
+PREFIX = $(CURDIR)/debian/$(package)/usr
 
 build:
 	rake compile_all
@@ -11,4 +12,5 @@ configure:
 	:
 
 install:
-	rake install prefix=$(CURDIR)/debian/$(package)/usr
+	echo $(PREFIX)
+	rake install prefix=$(PREFIX)


### PR DESCRIPTION
Make haconiwa binary installable to any path.

Default installation path is `$(CURDIR)/debian/$(package)/usr` .
If want to change the installation location, specify `PREFIX` at `make install` .
