### PR TITLE
Fix FiberedWorker#run return value

### DIFF
--- a/bintest/fixtures/hooks-test.haco
+++ b/bintest/fixtures/hooks-test.haco
@@ -60,6 +60,7 @@ apk --no-cache add ruby
     %w(before_fork before_start_wait after_fork after_chroot teardown_container).each do |hook|
       data << "\"#{hook}\": \"#{cache[hook]}\",\n"
     end
+    data << '"teardown": "OK",'
     data << '"dummy": 0 }'
     File.open("#{root.to_s}/log.json", 'w') do |f|
       f.puts data

--- a/bintest/hooks.rb
+++ b/bintest/hooks.rb
@@ -43,7 +43,7 @@ def wait_haconiwa(container_name)
   end
 end
 
-assert('haconiwa container is reloadable') do
+assert('haconiwa container hooks work well') do
   haconame = "hooks-#{rand(65535)}-#{$$}.haco"
   Dir.chdir File.dirname(HACONIWA_TMP_ROOT3) do
     @hash = SecureRandom.hex(4)
@@ -69,8 +69,8 @@ assert('haconiwa container is reloadable') do
     end
 
     result = JSON.parse(File.read "#{@rootfs}/log.json")
-    %w(before_fork before_start_wait after_fork teardown_container).each do |hook|
-      assert_equal "OK", result[hook]
+    %w(before_fork before_start_wait after_fork teardown_container teardown).each do |hook|
+      assert_equal "OK", result[hook], "assert that hook #{hook.inspect} was successful"
     end
     hook_txt = File.read "#{@rootfs}/after_chroot.txt"
     assert_equal "OK, this file is from after_chroot hook", hook_txt.chomp

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -82,8 +82,10 @@ module Haconiwa
     end
 
     def run_and_wait(pid)
+      # Haconiwa supervisor waits just 1 process
       @mainloop.pid = pid
-      p, s = *(@mainloop.run)
+      ret = @mainloop.run
+      p, s = *(ret.first)
       Haconiwa::Logger.puts "Container[Host PID=#{p}] finished: #{s.inspect}"
       return [p, s]
     end


### PR DESCRIPTION
According to [this change](https://github.com/udzura/mruby-fibered_worker/pull/10/files#diff-a6bd15363d22bd629088cdb36fb599a7R104-R123) , `FiberedWorker#run` returns not `[pid, Process::Status]`, but return s Array of this pairs.