### PR TITLE
Add DSL for hostname spec

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -88,6 +88,7 @@ module Haconiwa
       @signal_handler = SignalHandler.new
       @attached_capabilities = nil
       @name = "haconiwa-#{Time.now.to_i}"
+      @hostname = nil
       @container_pid_file = nil
       @pid = nil
       @daemon = false
@@ -160,6 +161,14 @@ module Haconiwa
     # aliases
     def chroot_to(dest)
       self.filesystem.rootfs = Rootfs.new(dest)
+    end
+
+    def hostname
+      @hostname || @name
+    end
+
+    def hostname=(host)
+      @hostname = host
     end
 
     def rootfs_owner(options)
@@ -474,6 +483,7 @@ module Haconiwa
         :@signal_handler,
         :@attached_capabilities,
         :@name,
+        :@hostname,
         :@container_pid_file,
         :@network_mountpoint,
         :@bootstrap,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -102,7 +102,7 @@ module Haconiwa
             Logger.debug("OK: apply_cgroup")
             apply_remount(base)
             Logger.debug("OK: apply_remount")
-            ::Procutil.sethostname(base.name) if base.namespace.flag?(::Namespace::CLONE_NEWUTS)
+            ::Procutil.sethostname(base.hostname) if base.namespace.flag?(::Namespace::CLONE_NEWUTS)
 
             apply_user_namespace(base.namespace)
             if base.namespace.use_guid_mapping?


### PR DESCRIPTION
* Past: `hostname` of new UTS namespace should be forced to its `config.name`
* Now: `hostname` can be customizable if you specify `unshare "uts"`
