### PR TITLE
Add a hook for performance monitoring or debug

### DIFF
--- a/mrblib/haconiwa/00_hookable.rb
+++ b/mrblib/haconiwa/00_hookable.rb
@@ -1,8 +1,9 @@
-module Haconiwa
+\module Haconiwa
   module Hookable
     VALID_HOOKS = [
       :setup,
       :before_fork,
+      :immediately_after_fork_on_parent,
       :after_fork,
       :after_network_created,
       :after_network_initialized,

--- a/mrblib/haconiwa/00_hookable.rb
+++ b/mrblib/haconiwa/00_hookable.rb
@@ -1,4 +1,4 @@
-\module Haconiwa
+module Haconiwa
   module Hookable
     VALID_HOOKS = [
       :setup,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -147,6 +147,8 @@ module Haconiwa
         ::Namespace.setns(::Namespace::CLONE_NEWPID, fd: init_pidns_fd.fileno) if init_pidns_fd
         base.pid = pid
         kick_ok.close
+        # This is only for debug or performance monitoring
+        invoke_general_hook(:immediately_after_fork_on_parent, base)
 
         if base.namespace.use_guid_mapping?
           Logger.info "Using gid/uid mapping in this container..."


### PR DESCRIPTION
Added `:immediately_after_fork_on_parent`. This is not for production hook, but useful to measure something in containers' bootup.