### PR TITLE
Add custom action script DSL entrypoint

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1148,6 +1148,7 @@ module Haconiwa
       @criu_bin_path = "/usr/local/sbin/criu"
       @criu_use_tcp_established = false
       @leave_running = false
+      @criu_custom_action_scripts = []
 
       @extra_criu_options = []
       @extra_criu_externals = []
@@ -1155,6 +1156,7 @@ module Haconiwa
     attr_accessor :target_syscall, :images_dir, :log_level,
                   :criu_log_file, :criu_service_address, :criu_bin_path,
                   :criu_use_tcp_established, :leave_running,
+                  :criu_custom_action_scripts,
                   :extra_criu_options, :extra_criu_externals
 
     def target_syscall(*args)
@@ -1163,6 +1165,11 @@ module Haconiwa
       else
         @target_syscall = args
       end
+    end
+
+    def add_action_script(script)
+      # Timing should be handled in scripts using CRTOOLS_SCRIPT_ACTION
+      @criu_custom_action_scripts << script
     end
 
     def dump(base, opt={})

--- a/mrblib/haconiwa/criu_service.rb
+++ b/mrblib/haconiwa/criu_service.rb
@@ -162,6 +162,9 @@ module Haconiwa
       if nw.enabled?
         cmds.options.concat(["--action-script", self_exe])
       end
+      checkpoint.criu_custom_action_scripts.each do |as|
+        cmds.options.concat(["--action-script", as])
+      end
 
       cmds.options.concat(["--root", @base.filesystem.root_path])
 


### PR DESCRIPTION
Haconiwa uses action script internally. If more script needed, now wa can utilize!
https://criu.org/Action_scripts