### PR TITLE
Add hacoboot_sampler tool

### DIFF
--- a/misc/hacoboot_sampler.bt
+++ b/misc/hacoboot_sampler.bt
@@ -1,0 +1,38 @@
+#!/usr/bin/env bpftrace
+/* Show max/min/avg of haconiwa's workload time to execve/listen called */
+
+usdt:./mruby/bin/haconiwa:haconiwa:bootstrap_phase_pass / arg0 == 1 /
+{
+    @run[tid] = nsecs;
+}
+
+usdt:./mruby/bin/haconiwa:haconiwa:bootstrap_phase_pass / arg0 == 2 /
+{
+    @this_fork[tid] = 1;
+}
+
+/* inherit process id */
+tracepoint:syscalls:sys_exit_clone / @this_fork[tid] /
+{
+    @boot[args->ret] = @run[tid];
+    delete(@this_fork[tid]);
+    delete(@run[tid]);
+}
+
+tracepoint:syscalls:sys_enter_execve / @boot[tid] && str(args->filename) == str($1) /
+{
+    $execve = nsecs - @boot[tid];
+    @execve__count = count();
+    @execve_avg = avg($execve);
+    @execve_max = max($execve);
+    @execve_min = min($execve);
+}
+
+tracepoint:syscalls:sys_exit_listen / @boot[tid] / {
+    $listen = nsecs - @boot[tid];
+    @listen__count = count();
+    @listen_avg = avg($listen);
+    @listen_max = max($listen);
+    @listen_min = min($listen);
+    delete(@boot[tid]);
+}

--- a/sample/criu-rails.haco
+++ b/sample/criu-rails.haco
@@ -38,16 +38,16 @@ Haconiwa.define do |config|
   config.network.veth_host = ::SHA1.sha1_hex(config.name + config.network.container_ip)[0, 8] + '_h'
 
   if ::Haconiwa.current_subcommand != "_restored"
-    config.add_async_hook msec: 2500 do |base|
-      begin
-        base.checkpoint.dump base
-      rescue => e
-        Haconiwa::Logger.puts "CRIU[hook]: dump failed: #{e.class}, #{e.message}"
-        ::Process.kill :TERM, base.pid
-      else
-        Haconiwa::Logger.puts "CRIU[hook]: dump OK!!"
-      end
-    end
+    # config.add_async_hook msec: 2500 do |base|
+    #   begin
+    #     base.checkpoint.dump base
+    #   rescue => e
+    #     Haconiwa::Logger.puts "CRIU[hook]: dump failed: #{e.class}, #{e.message}"
+    #     ::Process.kill :TERM, base.pid
+    #   else
+    #     Haconiwa::Logger.puts "CRIU[hook]: dump OK!!"
+    #   end
+    # end
   else
     config.add_async_hook msec: 2500, interval_msec: 2500 do |base|
       Haconiwa::Logger.puts "This is a restored process and hooks are available! PID=#{base.pid}"


### PR DESCRIPTION
This tool will get samples for elapsed time of:

* from time haconiwa is kicked to `execve` of the container begin
* from time haconiwa is kicked to `listen` and be ready

```console
$ sudo bpftrace misc/hacoboot_sampler.bt /u/app/helloworld/bin/rails                       
Attaching 5 probes...
^C

@execve__count: 3

@execve_avg: 70950886

@execve_max: 78633157

@execve_min: 59346736

@listen__count: 3

@listen_avg: 2240287035

@listen_max: 2359375184

@listen_min: 2100345924
```