### PR TITLE
Strictly check /proc/net/tcp by mruby-file-listen-checker

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -41,6 +41,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-lockfile', :github => 'udzura/mruby-lockfile'
   spec.add_dependency 'mruby-fibered_worker' , :github => 'udzura/mruby-fibered_worker'
   spec.add_dependency 'mruby-eventfd' , :github => 'matsumotory/mruby-eventfd'
+  spec.add_dependency 'mruby-file-listen-checker', github: 'pyama86/mruby-file-listen-checker'
 
   spec.add_dependency 'mruby-syslog'    , :github => 'udzura/mruby-syslog'
   spec.add_dependency 'mruby-sha1', :github => 'mattn/mruby-sha1'

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -37,16 +37,13 @@ module Haconiwa
         hook.set_signal!
         sig = hook.signal
         blk = hook.proc
-        check_str4 = "00000000:%04X" % hook.readiness_port
-        check_str6 = "00000000000000000000000000000000:%04X" % hook.readiness_port
         timeout = Time.now.to_i + hook.timeout
         @mainloop.register_timer(hook.signal, hook.timing, hook.interval) do
           begin
             next unless base.pid
             ::Haconiwa::Logger.debug("Check readiness: pid = #{base.pid}, port = #{hook.readiness_port}")
             cmd = "#{hook.nsenter_path} --net --pid --mount -t #{base.pid}"
-
-            if `#{cmd} cat /proc/net/tcp`.include?(check_str4) || `#{cmd} cat /proc/net/tcp6`.include?(check_str6)
+            if FileListenCheck.new(hook.readiness_ip, hook.readiness_port).listen? || FileListenCheck.new(hook.readiness_ipv6, hook.readiness_port).listen6?
               blk.call(base)
               if t = @mainloop.timer_for(sig)
                 ::Haconiwa::Logger.puts("Check hook stopped successfully")
@@ -171,10 +168,12 @@ module Haconiwa
         @timing ||= 50
         @interval = 10 if @interval <= 0
         @readiness_port = options[:port] || options[:readiness_port]
+        @readiness_ip = options[:readiness_ip] || "0.0.0.0"
+        @readiness_ipv6 = options[:readiness_ipv6] || "::"
         @timeout = options[:timeout] || 1800 # (sec)
         @nsenter_path = options[:nsenter_path] || 'nsenter'
       end
-      attr_accessor :readiness_port, :timeout, :nsenter_path
+      attr_accessor :readiness_ip, :readiness_ipv6, :readiness_port, :timeout, :nsenter_path
 
       def timing_default(opt)
         # skip

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -43,8 +43,9 @@ module Haconiwa
             next unless base.pid
             ::Haconiwa::Logger.debug("Check readiness: pid = #{base.pid}, port = #{hook.readiness_port}")
             cmd = "#{hook.nsenter_path} --net --pid --mount -t #{base.pid}"
-            if FileListenCheck.new(hook.readiness_ip, hook.readiness_port).listen? || FileListenCheck.new(hook.readiness_ipv6, hook.readiness_port).listen6?
-              blk.call(base)
+            ok = FileListenCheck.new(hook.readiness_ip, hook.readiness_port).listen? || FileListenCheck.new(hook.readiness_ipv6, hook.readiness_port).listen6?
+            blk.call(base, ok)
+            if ok
               if t = @mainloop.timer_for(sig)
                 ::Haconiwa::Logger.puts("Check hook stopped successfully")
                 t[0].stop


### PR DESCRIPTION
Hi Ucchi!
I made `/proc/net/tcp` parser.
If this is used, the fork by system becomes unnecessary!