### PR TITLE
Change to the same log level as readiness_hooks`s ::Haconiwa::Logger

### DIFF
--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -11,7 +11,7 @@ module Haconiwa
         hook.set_signal!
         blk = hook.proc
         @mainloop.register_timer(hook.signal, hook.timing, hook.interval) do
-          ::Haconiwa::Logger.warning("Async hook starting...")
+          ::Haconiwa::Logger.debug("Async hook starting...")
           begin
             blk.call(base)
           rescue => e


### PR DESCRIPTION
Hi @udzura san ! 

I want to change to the same log level as [readiness_hooks`s ::Haconiwa::Logger](https://github.com/haconiwa/haconiwa/compare/master...k1LoW:change-async-hook-log-level?expand=1#diff-12348d78a22ff4eed4eb2ce6878d67e8R44)

Because this ::Haconiwa::Logger output every hook.interval ( if `interval_msec: 3000` , out every 3sec. )

