### PR TITLE
speed up acquisition of bridge ip

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -42,6 +42,7 @@ MRuby::Gem::Specification.new('haconiwa') do |spec|
   spec.add_dependency 'mruby-fibered_worker' , :github => 'udzura/mruby-fibered_worker'
   spec.add_dependency 'mruby-eventfd' , :github => 'matsumotory/mruby-eventfd'
   spec.add_dependency 'mruby-file-listen-checker', github: 'pyama86/mruby-file-listen-checker'
+  spec.add_dependency 'mruby-ifaddr', github: 'pyama86/mruby-ifaddr'
 
   spec.add_dependency 'mruby-syslog'    , :github => 'udzura/mruby-syslog'
   spec.add_dependency 'mruby-sha1', :github => 'mattn/mruby-sha1'

--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -1125,7 +1125,7 @@ module Haconiwa
 
     private
     def detect_bridge_ip_mask(brname=@bridge_name)
-      `ip -f inet -o addr show #{brname}`.split[3].split('/')
+      ::IFAddr.get(brname)
     end
   end
 


### PR DESCRIPTION
Hi Ucchi!
I happend  `ip -f inet -o addr show brname` is very slow..
defenetaly ip command is throw NETLINK  command a lot. 
```
xxx.xxx # time ip -f inet -o addr show xxxxx
[snip]

real    0m3.385s
user    0m0.008s
sys     0m0.480s

# mruby-ifaddr
root@staging-compute-1:/tmp# time ./a.out 
xx.xxx.xxx.xxx

real    0m0.002s
user    0m0.000s
sys     0m0.000s
```

then, i made mruby-ifaddr is more simply than ip command.
https://github.com/pyama86/mruby-ifaddr/blob/master/src/mrb_ifaddr.c#L45

we can boot up fast and fast !