### PR TITLE
Reduce CPU usage in busy waitloop

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -84,7 +84,7 @@ module Haconiwa
       @async_hooks = []
       @readiness_hooks = []
       @cgroup_hooks = []
-      @wait_interval = 5
+      @wait_interval = 30 * 1000
       @environ = {}
       @lxcfs_root = nil
       @signal_handler = SignalHandler.new

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -1,6 +1,6 @@
 module Haconiwa
   class WaitLoop
-    def initialize(wait_interval=5)
+    def initialize(wait_interval=30 * 1000)
       @mainloop = FiberedWorker::MainLoop.new(interval: wait_interval)
       @wait_interval = wait_interval
     end


### PR DESCRIPTION
After https://github.com/udzura/mruby-fibered_worker/pull/12 is released, wa can handle worker's death by SIGCHLD handler. So just use blocking `sigtimedwait`, then we can reap children in real-time.