### PR TITLE
Add loop count limit / Add accessor for current timewr in astnc loop

### DIFF
--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -1,4 +1,12 @@
 module Haconiwa
+  def self.current_timer=(t)
+    @current_timer = t
+  end
+
+  def self.current_timer
+    @current_timer
+  end
+
   class WaitLoop
     def initialize(wait_interval=30 * 1000)
       @mainloop = FiberedWorker::MainLoop.new(interval: wait_interval)
@@ -14,7 +22,9 @@ module Haconiwa
         @mainloop.register_timer(hook.signal, hook.timing, hook.interval) do
           ::Haconiwa::Logger.debug("Async hook starting...")
           begin
+            ::Haconiwa.current_timer = @mainloop.timer_for(hook.signal)
             blk.call(base)
+            ::Haconiwa.current_timer = nil
             cnt += 1
             if hook.interval > 0 && (hook.limit_count && cnt >= hook.limit_count)
               if t = @mainloop.timer_for(hook.signal)

--- a/sample/criu.haco
+++ b/sample/criu.haco
@@ -53,8 +53,10 @@ Haconiwa.define do |conf|
       # end
     end
 
-    config.add_async_hook(sec: 10, interval_msec: 10 * 1000) do
-      Haconiwa::Logger.puts "Hi! #{`date`}"
+    config.add_async_hook(sec: 10, interval_msec: 500, limit_count: 10) do
+      @cnt ||= 0
+      Haconiwa::Logger.puts "Hi! #{`date`} #{@cnt}"
+      @cnt += 1
     end
 
     config.add_readiness_hook(port: 80, timeout: 10, interval_msec: 250) do |base, ok|


### PR DESCRIPTION
Example log: 

```
Jan 28 07:32:40 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Container fork success and going to wait: pid=21761      
Jan 28 07:32:40 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Port 80 looks ready, yey!!! pid = 21761                  
Jan 28 07:32:40 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Check hook stopped successfully                          
...
Jan 28 07:32:50 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:50 UTC 2020#012 0                   
Jan 28 07:32:50 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:50 UTC 2020#012 1                   
Jan 28 07:32:51 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:51 UTC 2020#012 2                   
Jan 28 07:32:51 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:51 UTC 2020#012 3                   
Jan 28 07:32:52 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:52 UTC 2020#012 4                   
Jan 28 07:32:52 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:52 UTC 2020#012 5                   
Jan 28 07:32:53 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:53 UTC 2020#012 6                   
Jan 28 07:32:53 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:53 UTC 2020#012 7                   
Jan 28 07:32:54 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:54 UTC 2020#012 8                   
Jan 28 07:32:54 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Hi! Tue Jan 28 07:32:54 UTC 2020#012 9                   
Jan 28 07:32:54 ubuntu-bionic haconiwa.haconiwa-1580196760[21720]: Asuyc hook stopped due to count limit                    

```