### PR TITLE
block chld signal before fork

### DIFF
--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -81,6 +81,8 @@ module Haconiwa
         end
         done, kick_ok = IO.pipe
         Haconiwa.probe_phase_pass(PHASE_START_FORK, hpid)
+
+        base.waitloop.block_signals([:CHLD])
         pid = Process.fork do
           Haconiwa.probe_phase_pass(PHASE_CONTAINER_START, hpid)
           invoke_general_hook(:after_fork, base)

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -137,6 +137,10 @@ module Haconiwa
       end
     end
 
+    def block_signals(signals)
+      FiberedWorker.sigprocmask(signals.map { |v| FiberedWorker.obj2signo(v) })
+    end
+
     def run_and_wait(pid)
       # Haconiwa supervisor waits just 1 process
       @mainloop.pid = pid


### PR DESCRIPTION
Under the following condition, the container became a zombie process and Supervisor never terminate;

- Container process exit immediately
- Supervisor take a long time before do `waitloop.run_and_wait`
  - e.g., `:immediately_after_fork_on_parent` hook took a long time.

It seems that the `CHLD` signal is ignored between forking the process and running the waitloop.
I think we can avoid this issue by running `sigprocmask` to block `CHLD` signal before forking, rather than when starting waitloop.