### PR TITLE
Allow to use legacy watchdog as option

### DIFF
--- a/mrblib/haconiwa/base.rb
+++ b/mrblib/haconiwa/base.rb
@@ -22,6 +22,7 @@ module Haconiwa
                   :readiness_hooks,
                   :cgroup_hooks,
                   :wait_interval,
+                  :use_legacy_watchdog,
                   :environ,
                   :lxcfs_root,
                   :attached_capabilities,
@@ -85,6 +86,7 @@ module Haconiwa
       @readiness_hooks = []
       @cgroup_hooks = []
       @wait_interval = 30 * 1000
+      @use_legacy_watchdog = false
       @environ = {}
       @lxcfs_root = nil
       @signal_handler = SignalHandler.new
@@ -488,6 +490,7 @@ module Haconiwa
         :@readiness_hooks,
         :@cgroup_hooks,
         :@wait_interval,
+        :@use_legacy_watchdog,
         :@environ,
         :@lxcfs_root,
         :@signal_handler,

--- a/mrblib/haconiwa/runner.rb
+++ b/mrblib/haconiwa/runner.rb
@@ -176,6 +176,7 @@ module Haconiwa
         run_base_setup_before_wait
         Logger.puts "Container fork success and going to wait: pid=#{pid}"
         Haconiwa.probe_phase_pass(PHASE_START_WAIT, hpid)
+        base.waitloop.use_legacy_watchdog = base.use_legacy_watchdog
         pid, status = base.waitloop.run_and_wait(pid)
         Haconiwa.probe_phase_pass(PHASE_END_WAIT, hpid)
         run_cleanups_after_exit(status)

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -10,6 +10,7 @@ module Haconiwa
   class WaitLoop
     def initialize(wait_interval=30 * 1000, use_legacy_watchdog=false)
       @mainloop = FiberedWorker::MainLoop.new(interval: wait_interval, use_legacy_watchdog: use_legacy_watchdog)
+      @use_legacy_watchdog = use_legacy_watchdog
       @wait_interval = wait_interval
     end
     attr_accessor :mainloop, :wait_interval, :use_legacy_watchdog

--- a/mrblib/haconiwa/wait_loop.rb
+++ b/mrblib/haconiwa/wait_loop.rb
@@ -8,11 +8,11 @@ module Haconiwa
   end
 
   class WaitLoop
-    def initialize(wait_interval=30 * 1000)
-      @mainloop = FiberedWorker::MainLoop.new(interval: wait_interval)
+    def initialize(wait_interval=30 * 1000, use_legacy_watchdog=false)
+      @mainloop = FiberedWorker::MainLoop.new(interval: wait_interval, use_legacy_watchdog: use_legacy_watchdog)
       @wait_interval = wait_interval
     end
-    attr_accessor :mainloop, :wait_interval
+    attr_accessor :mainloop, :wait_interval, :use_legacy_watchdog
 
     def register_hooks(base)
       base.async_hooks.each do |hook|
@@ -144,6 +144,7 @@ module Haconiwa
     def run_and_wait(pid)
       # Haconiwa supervisor waits just 1 process
       @mainloop.pid = pid
+      @mainloop.use_legacy_watchdog = self.use_legacy_watchdog
       ret = @mainloop.run
       p, s = *(ret.first)
       Haconiwa::Logger.puts "Container[Host PID=#{p}] finished: #{s.inspect}"


### PR DESCRIPTION
mruby-fibered_workerにおける `use_legacy_watchdog` オプションをhacofileから指定できるようにします
https://github.com/udzura/mruby-fibered_worker/blob/master/mrblib/fiberer_worker/main_loop.rb#L7

```ruby
Haconiwa.define do |config|
  config.use_legacy_watchdog = true
  ...
```